### PR TITLE
For loops with dynamic ranges

### DIFF
--- a/src/main/scala/Errors.scala
+++ b/src/main/scala/Errors.scala
@@ -24,6 +24,9 @@ object Errors {
   case class UnrollRangeError(pos: Position, rSize: Int, uFactor: Int) extends TypeError(
     s"Cannot unroll range of size $rSize by factor $uFactor.", pos)
 
+  case class InvalidDynamicUnroll(pos: Position, uFactor: Int) extends TypeError(
+    s"Cannot unroll dynamic loop range with unroll factor $uFactor.", pos)
+
   case class InvalidIndex(id: Id, actual: Type) extends TypeError(
     s"Invalid indexing type for `$id'. Expected: TIndex or TSizedInt, actual: $actual", id.pos)
 

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -152,7 +152,11 @@ private class FuseParser extends RegexParsers with PackratParsers {
 
   lazy val crange: P[CRange] = positioned {
     parens("let" ~> iden ~ "=" ~ number ~ ".." ~ number) ~ ("unroll" ~> number).? ^^ {
-      case id ~ _ ~ s ~ _ ~ e ~ u => CRange(id, s, e, u.getOrElse(1))
+      case id ~ _ ~ s ~ _ ~ e ~ u => StaticRange(id, s, e, u.getOrElse(1))
+    } |
+    parens("let" ~> iden ~ "=" ~ expr ~ ".." ~ expr ~ "step" ~ expr) ~ ("unroll" ~> number).? ^^ {
+      case id ~ _ ~ s ~ _ ~ e ~ _ ~ step ~ u =>
+        DynamicRange(id, s, e, step, u.getOrElse(1))
     }
   }
   lazy val cfor: P[Command] = positioned {

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -99,8 +99,8 @@ object Cpp {
         case DynamicRange(_, s, e, step, _) => (s, e, step)
       }
       parens {
-        "int" <+> range.iter <+> "=" <+> value(start) <> semi <+>
-        range.iter <+> "<" <+> value(end) <> semi <+>
+        "int" <+> range.iter <+> "=" <+> start <> semi <+>
+        range.iter <+> "<" <+> end <> semi <+>
         range.iter <> "+=" <> step
       }
     }

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -93,10 +93,16 @@ object Cpp {
      * Turns a range object into the parameter of a `for` loop.
      * (int <id> = <s>; <id> < <e>; <id>++)
      */
-    def emitRange(range: CRange): Doc = parens {
-      "int" <+> range.iter <+> "=" <+> value(range.s) <> semi <+>
-      range.iter <+> "<" <+> value(range.e) <> semi <+>
-      range.iter <> "++"
+    def emitRange(range: CRange): Doc = {
+      val (start, end, step): (Doc, Doc, Doc) = range match {
+        case StaticRange(_, s, e, _) => (value(s), value(e), value(1))
+        case DynamicRange(_, s, e, step, _) => (s, e, step)
+      }
+      parens {
+        "int" <+> range.iter <+> "=" <+> value(start) <> semi <+>
+        range.iter <+> "<" <+> value(end) <> semi <+>
+        range.iter <> "+=" <> step
+      }
     }
 
     implicit def emitCmd(c: Command): Doc = c match {

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -29,7 +29,7 @@ private class VivadoBackend extends CppLike {
 
   def emitFor(cmd: CFor): Doc =
     "for" <> emitRange(cmd.range) <+> scope {
-      unroll(cmd.range.u) <>
+      unroll(cmd.range.unroll) <>
       cmd.par <>
       (if (cmd.combine != CEmpty) line <> text("// combiner:") <@> cmd.combine
        else emptyDoc)


### PR DESCRIPTION
[WIP] Add support for `for` loops with dynamic ranges and steps.

@sa2257 @sampsyo @tedbauer comments for step syntax. Right now, it is:
```
for (let i = 0..10 step 2) ...
```

- Add support for loops with arbitrary expressions in place of start and end ranges.
- These loops cannot be unrolled.
- I'm worried that adding these is moving us towards the Vivado problem where certain magic constructs in the language can be unrolled whiles others can't be. Maybe it would be better to just use `while` loops as the un-`unroll`able loops and treating this as syntactic sugar.