### PR TITLE
Remove Kiama dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ scalaVersion := "2.12.8"
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
-  "org.bitbucket.inkytonik.kiama" %% "kiama" % "2.2.0",
   "com.github.scopt" %% "scopt" % "3.7.1",
   "com.outr" %% "scribe" % "2.7.2",
   "com.lihaoyi" %% "sourcecode" % "0.1.5"
@@ -43,7 +42,8 @@ getHeaders := {
   val jsonHppLoc = new File("src/main/resources/headers/json.hpp")
 
   if (!jsonHppLoc.exists()) {
-    val jsonHpp = new URL("https://raw.githubusercontent.com/nlohmann/json/develop/single_include/nlohmann/json.hpp")
+    val jsonHpp = new URL(
+      "https://raw.githubusercontent.com/nlohmann/json/develop/single_include/nlohmann/json.hpp")
     val cmd = Seq("wget", jsonHpp, "--directory-prefix", jsonHppLoc.toString)
     // sys.process DSL magic!
     jsonHpp #> jsonHppLoc !!

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 name := "Fuse"
-version := "0.0.1"
+version := "0.0.2"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.0" % "test",
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
   "com.github.scopt" %% "scopt" % "3.7.1",
-  "com.outr" %% "scribe" % "2.7.2",
-  "com.lihaoyi" %% "sourcecode" % "0.1.5"
+  "com.outr" %% "scribe" % "2.7.9",
+  "com.lihaoyi" %% "sourcecode" % "0.1.7"
 )
 
 scalacOptions ++= Seq(
@@ -17,7 +17,6 @@ scalacOptions ++= Seq(
   "-feature",
   "-Ywarn-unused",
   "-Ywarn-value-discard",
-  "-Yno-adapted-args",
   "-Xfatal-warnings"
 )
 

--- a/fuse
+++ b/fuse
@@ -1,4 +1,1 @@
-#!/bin/bash
-
-here=`dirname $(readlink $0 || echo $0)`
-java -jar $here/target/scala-2.12/fuse.jar $@
+/home/rachit/git/fuse/target/scala-2.13/fuse.jar

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -119,8 +119,12 @@ object Cpp {
       case CPar(c1, c2) => c1 <@> c2
       case CSeq(c1, c2) => c1 <@> text("//---") <@> c2
       case l:CLet => emitLet(l)
-      case CIf(cond, cons, alt) =>
-        text("if") <> parens(cond) <> scope (cons) <+> text("else") <> scope(alt)
+      case CIf(cond, cons, alt) => {
+        text("if") <+> parens(cond) <+> scope (cons) <> (alt match {
+          case CEmpty => emptyDoc
+          case _ => space <> text("else") <+> scope(alt)
+        })
+      }
       case f:CFor => emitFor(f)
       case w:CWhile => emitWhile(w)
       case CDecorate(dec) => value(dec)

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -1,6 +1,7 @@
 package fuselang.backend
+import PrettyPrint.Doc._
+import PrettyPrint.Doc
 
-import org.bitbucket.inkytonik.kiama.output._
 import fuselang.common._
 import Syntax._
 import CompilerError._
@@ -10,34 +11,30 @@ object Cpp {
    * A C++ backend that only emits one dimensionals arrays and one dimensional
    * array accesses.
    */
-  trait CppLike extends PrettyPrinter {
+  trait CppLike {
     /**
      * This class aggressively uses Scala's implicitConversions. Make sure
      * that implicits classes never leak.
      * Implicit classes: https://docs.scala-lang.org/tour/implicit-conversions.html
      *
-     * We also use the Kiama pretty printer combinators to generate the code.
-     * For reference: https://bitbucket.org/inkytonik/kiama/src/master/wiki/PrettyPrinting.md?fileviewer=file-view-default
      */
     import scala.language.implicitConversions
 
-    override val defaultIndent = 2
-
-    def quote(id: Doc) = dquotes(id)
+    val defaultIndent = 2
 
     /**
      * Helper to generate a variable declaration with an initial value.
      */
-    def cBind(id: Doc, rhs: Doc): Doc = {
-      "auto" <+> id <+> "=" <+> rhs <> semi
+    def cBind(id: String, rhs: Doc): Doc = {
+      text("auto") <+> text(id) <+> text("=") <+> rhs <> semi
     }
 
     /**
      * Helper to generate a function call that might have a type parameter
      */
-    def cCall(f: Doc, tParam: Option[Doc], args: List[Doc]): Doc = {
-      f <> (if (tParam.isDefined) angles(tParam.get) else emptyDoc) <>
-      parens(hsep(args, ","))
+    def cCall(f: String, tParam: Option[Doc], args: List[Doc]): Doc = {
+      text(f) <> (if (tParam.isDefined) angles(tParam.get) else emptyDoc) <>
+      parens(hsep(args, comma))
     }
 
     /**
@@ -61,7 +58,7 @@ object Cpp {
      * Emit while loops.
      */
     def emitWhile(cmd: CWhile): Doc =
-      "while" <> parens(cmd.cond) <+> scope(cmd.body)
+      text("while") <> parens(cmd.cond) <+> scope(cmd.body)
 
     /**
      * Used to emit function headers. All C++ backends will convert the function
@@ -83,11 +80,11 @@ object Cpp {
     implicit def IdToString(id: Id): Doc = value(id.v)
 
     def scope(doc: Doc): Doc =
-      lbrace <@> indent(doc) <@> rbrace
+      lbrace <@> nest(doc, defaultIndent) <@> rbrace
 
-    def emitBaseInt(v: Int, base: Int) = base match {
+    def emitBaseInt(v: Int, base: Int): String = base match {
       case 8 => s"0${Integer.toString(v, 8)}"
-      case 10 => v
+      case 10 => v.toString
       case 16 => s"0x${Integer.toString(v, 16)}"
     }
 
@@ -98,13 +95,13 @@ object Cpp {
       case EFloat(f) => value(f)
       case EBool(b) => value(if(b) 1 else 0)
       case EVar(id) => value(id)
-      case EBinop(op, e1, e2) => parens(e1 <+> op.toString <+> e2)
+      case EBinop(op, e1, e2) => parens(e1 <+> text(op.toString) <+> e2)
       case EArrAccess(id, idxs) =>
         id <> ssep(idxs.map(idx => brackets(emitExpr(idx))), emptyDoc)
       case EArrLiteral(idxs) => braces(hsep(idxs.map(idx => emitExpr(idx)), comma))
       case ERecAccess(rec, field) => rec <> dot <> field
       case ERecLiteral(fs) => scope {
-        hsep(fs.toList.map({ case (id, expr) => "." <> id <+> "=" <+> expr }), comma)
+        hsep(fs.toList.map({ case (id, expr) => dot <> id <+> equal <+> expr }), comma)
       }
     }
 
@@ -113,9 +110,9 @@ object Cpp {
      * (int <id> = <s>; <id> < <e>; <id>++)
      */
     def emitRange(range: CRange): Doc = parens {
-      "int" <+> range.iter <+> "=" <+> value(range.s) <> semi <+>
-      range.iter <+> "<" <+> value(range.e) <> semi <+>
-      range.iter <> "++"
+      text("int") <+> range.iter <+> equal <+> value(range.s) <> semi <+>
+      range.iter <+> text("<") <+> value(range.e) <> semi <+>
+      range.iter <> text("++")
     }
 
     implicit def emitCmd(c: Command): Doc = c match {
@@ -123,13 +120,13 @@ object Cpp {
       case CSeq(c1, c2) => c1 <@> text("//---") <@> c2
       case l:CLet => emitLet(l)
       case CIf(cond, cons, alt) =>
-        "if" <> parens(cond) <> scope (cons) <+> "else" <> scope(alt)
+        text("if") <> parens(cond) <> scope (cons) <+> text("else") <> scope(alt)
       case f:CFor => emitFor(f)
       case w:CWhile => emitWhile(w)
-      case CDecorate(value) => value
-      case CUpdate(lhs, rhs) => lhs <+> "=" <+> rhs <> semi
-      case CReduce(rop, lhs, rhs) => lhs <+> rop.toString <+> rhs <> semi
-      case CReturn(e) => "return" <+> e <> semi
+      case CDecorate(dec) => value(dec)
+      case CUpdate(lhs, rhs) => lhs <+> equal <+> rhs <> semi
+      case CReduce(rop, lhs, rhs) => lhs <+> text(rop.toString) <+> rhs <> semi
+      case CReturn(e) => text("return") <+> e <> semi
       case CExpr(e) => e <> semi
       case CEmpty => emptyDoc
       case _:CView | _:CSplit =>
@@ -153,12 +150,12 @@ object Cpp {
     def emitDef(defi: Definition): Doc = defi match {
       case func:FuncDef => emitFunc(func)
       case RecordDef(name, fields) =>
-        "typedef struct" <+> scope {
+        text("typedef struct") <+> scope {
           vsep(fields.toList.map({ case (id, typ) => emitType(typ) <+> id <> semi }))
         } <+> name <> semi
     }
 
-    def emitInclude(incl: Include): Doc = "#include" <+> quote(incl.name)
+    def emitInclude(incl: Include): Doc = text("#include") <+> quote(text(incl.name))
 
   }
 

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -142,13 +142,14 @@ object Cpp {
       case _ => emitType(typ) <+> id
     }
 
-    def emitFunc(func: FuncDef, entry: Boolean = false): Doc = func match { case func@FuncDef(id, args, ret, bodyOpt) =>
-      val as = hsep(args.map(decl => emitDecl(decl.id, decl.typ)), comma)
-      // If body is not defined, this is an extern. Elide the definition.
-      bodyOpt.map(body => emitType(ret) <+> id <> parens(as) <+> scope {
-        emitFuncHeader(func, entry) <@>
-        body
-      }).getOrElse(emptyDoc)
+    def emitFunc(func: FuncDef, entry: Boolean = false): Doc = func match {
+      case func@FuncDef(id, args, ret, bodyOpt) =>
+        val as = hsep(args.map(decl => emitDecl(decl.id, decl.typ)), comma)
+        // If body is not defined, this is an extern. Elide the definition.
+        bodyOpt.map(body => emitType(ret) <+> id <> parens(as) <+> scope {
+          emitFuncHeader(func, entry) <@>
+          body
+        }).getOrElse(emptyDoc)
     }
 
     def emitDef(defi: Definition): Doc = defi match {

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -80,7 +80,7 @@ object Cpp {
     implicit def IdToString(id: Id): Doc = value(id.v)
 
     def scope(doc: Doc): Doc =
-      lbrace <@> nest(doc, defaultIndent) <@> rbrace
+      lbrace <> nest(emptyDoc <@> doc, defaultIndent) <@> rbrace
 
     def emitBaseInt(v: Int, base: Int): String = base match {
       case 8 => s"0${Integer.toString(v, 8)}"

--- a/src/main/scala/backends/CppRunnable.scala
+++ b/src/main/scala/backends/CppRunnable.scala
@@ -1,6 +1,8 @@
 package fuselang.backend
 
 import Cpp._
+import PrettyPrint.Doc
+import PrettyPrint.Doc._
 
 import fuselang.common._
 import Syntax._
@@ -16,24 +18,24 @@ import CompilerError._
 private class CppRunnable extends CppLike {
 
   def emitType(typ: Type): Doc = typ match {
-    case _:TVoid => "void"
-    case _:TBool => "bool"
-    case _:TIndex | _:TStaticInt => "int"
-    case TSizedInt(_, un) => if (un) "unsigned int" else "int"
-    case _:TFloat => "float"
-    case _:TDouble => "double"
+    case _:TVoid => text("void")
+    case _:TBool => text("bool")
+    case _:TIndex | _:TStaticInt => text("int")
+    case TSizedInt(_, un) => text(if (un) "unsigned int" else "int")
+    case _:TFloat => text("float")
+    case _:TDouble => text("double")
     case TArray(typ, dims) =>
-      dims.foldLeft(emitType(typ))({ case (acc, _) => "vector" <> angles(acc) })
-    case TRecType(n, _) => n
+      dims.foldLeft(emitType(typ))({ case (acc, _) => text("vector") <> angles(acc) })
+    case TRecType(n, _) => value(n)
     case _:TFun =>
       throw Impossible("Cannot emit function types")
-    case TAlias(n) => n
+    case TAlias(n) => value(n)
   }
 
-  def emitArrayDecl(ta: TArray, id: Id) = emitType(ta) <+> s"$id"
+  def emitArrayDecl(ta: TArray, id: Id) = emitType(ta) <+> text(s"$id")
 
   def emitFor(cmd: CFor): Doc =
-    "for" <> emitRange(cmd.range) <+> scope {
+    text("for") <> emitRange(cmd.range) <+> scope {
       cmd.par <> {
         if (cmd.combine != CEmpty)
           line <> text("// combiner:") <@> cmd.combine
@@ -63,9 +65,10 @@ private class CppRunnable extends CppLike {
         (quote(typeName), typeName)
       }
       case arr@TArray(_, dims) => {
-        val typeName = quote(s"${arr.typ}${dims.map(_ => "[]").mkString}")
+        val typeName = quote(text(s"${arr.typ}${dims.map(_ => "[]").mkString}"))
         val cType =
-          "n_dim_vec_t" <> angles(emitType(arr.typ) <> comma <+> dims.length.toString)
+          text("n_dim_vec_t") <>
+        angles(emitType(arr.typ) <> comma <+> value(dims.length))
         (typeName, cType)
       }
       case t =>
@@ -73,7 +76,7 @@ private class CppRunnable extends CppLike {
     }
 
     cBind(s"${id}",
-      cCall("get_arg", Some(cTyp), List(quote(id), typeName, "v")))
+      cCall("get_arg", Some(cTyp), List(quote(id), typeName, text("v"))))
 
   }}
 
@@ -83,15 +86,17 @@ private class CppRunnable extends CppLike {
    * See: https://github.com/nlohmann/json#basic-usage
    */
   private def recordHelpers: RecordDef => Doc = { case RecordDef(name, fields) =>
-    "void to_json" <> parens(s"nlohmann::json& j, const ${name}& r") <+> scope {
-      "j =" <+> "nlohmann::json" <> braces(hsep({
-        fields.map({ case (id, _) => braces(quote(id) <> comma <+> s"r.$id")}).toList
+    text("void to_json") <>
+    parens(text(s"nlohmann::json& j, const ${name}& r")) <+> scope {
+      text("j =") <+> text("nlohmann::json") <> braces(hsep({
+        fields.map({ case (id, _) => braces(quote(id) <> comma <+> text(s"r.$id"))}).toList
       }, comma)) <> semi
     } <@>
-    "void from_json" <> parens(s"const nlohmann::json& j, ${name}& r") <+> scope {
+    text("void from_json") <>
+    parens(text(s"const nlohmann::json& j, ${name}& r")) <+> scope {
       vsep({
         fields.map({ case (id, _) =>
-          "j.at" <> parens(quote(id)) <> ".get_to" <> parens(s"r.$id") <> semi
+          text("j.at") <> parens(quote(id)) <> text(".get_to") <> parens(text(s"r.$id")) <> semi
         }).toList
       })
     }
@@ -126,24 +131,26 @@ private class CppRunnable extends CppLike {
     // Generate a main function that parses are kernel parameters and calls
     // the kernel function.
     val main = value("int main(int argc, char** argv)") <+> scope {
-      "using namespace flattening;" <@>
-      cBind("v", cCall("parse_data", None, List("argc", "argv"))) <> semi <@>
+      text("using namespace flattening;") <@>
+      cBind("v", cCall("parse_data", None, List(text("argc"), text("argv")))) <> semi <@>
       getArgs <@>
       cCall(c.kernelName, None, p.decls.map(decl => value(decl.id.v))) <> semi <@>
-      "return 0" <> semi
+      text("return 0") <> semi
     }
 
     // Emit string
-    super.pretty(kernel <@> main).layout
+    (kernel <@> main).pretty
   }
 }
 
 private class CppRunnableHeader extends CppRunnable {
   override def emitCmd(c: Command): Doc = emptyDoc
 
-  override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match { case FuncDef(id, args, ret, _) =>
-    val as = hsep(args.map(d => emitDecl(d.id, d.typ)), comma)
-    emitType(ret) <+> id <> parens(as) <> semi
+  override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match {
+    case FuncDef(id, args, ret, _) => {
+      val as = hsep(args.map(d => emitDecl(d.id, d.typ)), comma)
+      emitType(ret) <+> id <> parens(as) <> semi
+    }
   }
 
   override def emitProg(p: Prog, c: Config) = {
@@ -154,7 +161,7 @@ private class CppRunnableHeader extends CppRunnable {
       vsep (p.defs.map(emitDef)) <@>
       emitFunc(FuncDef(Id(c.kernelName), p.decls, TVoid(), None), true)
 
-    super.pretty(declarations).layout
+    declarations.pretty
   }
 }
 

--- a/src/main/scala/backends/CppRunnable.scala
+++ b/src/main/scala/backends/CppRunnable.scala
@@ -88,9 +88,9 @@ private class CppRunnable extends CppLike {
   private def recordHelpers: RecordDef => Doc = { case RecordDef(name, fields) =>
     text("void to_json") <>
     parens(text(s"nlohmann::json& j, const ${name}& r")) <+> scope {
-      text("j =") <+> text("nlohmann::json") <> braces(hsep({
+      text("j =") <+> text("nlohmann::json") <> braces(commaSep({
         fields.map({ case (id, _) => braces(quote(id) <> comma <+> text(s"r.$id"))}).toList
-      }, comma)) <> semi
+      })) <> semi
     } <@>
     text("void from_json") <>
     parens(text(s"const nlohmann::json& j, ${name}& r")) <+> scope {
@@ -148,7 +148,7 @@ private class CppRunnableHeader extends CppRunnable {
 
   override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match {
     case FuncDef(id, args, ret, _) => {
-      val as = hsep(args.map(d => emitDecl(d.id, d.typ)), comma)
+      val as = commaSep(args.map(d => emitDecl(d.id, d.typ)))
       emitType(ret) <+> id <> parens(as) <> semi
     }
   }

--- a/src/main/scala/backends/Document.scala
+++ b/src/main/scala/backends/Document.scala
@@ -1,0 +1,126 @@
+/**
+ * Lightweight library from the deprecated scala.text distribution.
+ */
+
+package fuselang.backend
+
+import java.io.Writer
+
+object PrettyPrint {
+  case object DocNil extends Doc
+  case object DocBreak extends Doc
+  case object DocSpace extends Doc
+  case class DocText(txt: String) extends Doc
+  case class DocNest(indent: Int, doc: Doc) extends Doc
+  case class DocCons(hd: Doc, tl: Doc) extends Doc
+
+  /**
+   * A basic pretty-printing library, based on Lindig's strict version
+   * of Wadler's adaptation of Hughes' pretty-printer.
+   *
+   * @author Michel Schinz
+   * @version 1.0
+   */
+  abstract class Doc {
+    def <>(hd: Doc): Doc = DocCons(this, hd)
+    def <@>(hd: Doc): Doc = this <> DocBreak <> hd
+    def <+>(hd: Doc): Doc = this <> DocSpace <> hd
+
+    def pretty: String = {
+      val writer = new java.io.StringWriter()
+      format(writer)
+      writer.toString
+    }
+
+    /**
+     * Format this Doc on `writer`.
+     */
+    def format(writer: Writer) {
+      type FmtState = (Int, Doc)
+
+      def spaces(n: Int) {
+        var rem = n
+        while (rem >= 16) { writer write "                "; rem -= 16 }
+        if (rem >= 8)     { writer write "        "; rem -= 8 }
+        if (rem >= 4)     { writer write "    "; rem -= 4 }
+        if (rem >= 2)     { writer write "  "; rem -= 2}
+        if (rem == 1)     { writer write " " }
+      }
+
+      def fmt(k: Int, state: List[FmtState]): Unit = state match {
+        case List() => ()
+        case (_, DocNil) :: z => fmt(k, z)
+        case (i, DocCons(h, t)) :: z => fmt(k, (i, h) :: (i, t) :: z)
+        case (_, DocText(t)) :: z => {
+          writer.write(t)
+          fmt(k + t.length(), z)
+        }
+        case (i, DocNest(ii, d)) :: z => fmt(k, (i + ii, d) :: z)
+        case (i, DocBreak) :: z => {
+          writer.write("\n")
+          spaces(i)
+          fmt(i, z)
+        }
+        case (_, DocSpace) :: z => {
+          writer.write(" "); fmt(k + 1, z)
+        }
+        case _ => ()
+      }
+
+      fmt(0, List((0, this)))
+    }
+  }
+
+  object Doc {
+    /** The empty Doc */
+    def emptyDoc = DocNil
+    def line = DocBreak
+    def space = DocSpace
+
+    /** A Doc consisting of some text literal */
+    def text(s: String): Doc = DocText(s)
+
+    def value(v: Any): Doc = text(v.toString)
+
+    /** Common primitives */
+    def semi: Doc = text(";")
+    def comma: Doc = text(",")
+    def dot: Doc = text(".")
+    def equal: Doc = text("=")
+    def lbrace: Doc = text("{")
+    def rbrace: Doc = text("}")
+
+    /** A nested Doc, which will be indented as specified. */
+    def nest(d: Doc, i: Int): Doc = DocNest(i, d)
+
+    def folddoc(ds: Seq[Doc], f: (Doc, Doc) => Doc) =
+      if (ds.isEmpty) emptyDoc
+      else ds.tail.foldLeft(ds.head)(f)
+
+    /** Builder functions */
+    def hsep(ds: Seq[Doc], sep: Doc): Doc =
+      folddoc(ds, (_ <> sep <> _))
+
+    def ssep(ds: Seq[Doc], sep: Doc): Doc =
+      folddoc(ds, (_ <> sep <> _))
+
+    def hsep(ds: Seq[Doc]): Doc =
+      folddoc(ds, (_ <+> _))
+
+    def vsep(ds: Seq[Doc]): Doc =
+      folddoc(ds, (_ <@> _))
+
+    def enclose(l: Doc, d: Doc, r: Doc) = l <> d <> r
+
+    def surround(d: Doc, s: Doc) = enclose(s, d, s)
+
+    /** Common functions **/
+
+    def quote(d: Doc) = surround(d, text("\""))
+
+    def parens(d: Doc) = enclose(text("("), d, text(")"))
+    def braces(d: Doc) = enclose(text("{"), d, text("}"))
+    def brackets(d: Doc) = enclose(text("["), d, text("]"))
+    def angles(d: Doc) = enclose(text("<"), d, text(">"))
+  }
+}

--- a/src/main/scala/backends/Document.scala
+++ b/src/main/scala/backends/Document.scala
@@ -47,27 +47,27 @@ object PrettyPrint {
         if (rem == 1)     { writer write " " }
       }
 
-      def fmt(k: Int, state: List[FmtState]): Unit = state match {
+      def fmt(state: List[FmtState]): Unit = state match {
         case List() => ()
-        case (_, DocNil) :: z => fmt(k, z)
-        case (i, DocCons(h, t)) :: z => fmt(k, (i, h) :: (i, t) :: z)
+        case (_, DocNil) :: z => fmt(z)
+        case (i, DocCons(h, t)) :: z => fmt((i, h) :: (i, t) :: z)
         case (_, DocText(t)) :: z => {
           writer.write(t)
-          fmt(k + t.length(), z)
+          fmt(z)
         }
-        case (i, DocNest(ii, d)) :: z => fmt(k, (i + ii, d) :: z)
+        case (i, DocNest(ii, d)) :: z => fmt((i + ii, d) :: z)
         case (i, DocBreak) :: z => {
           writer.write("\n")
           spaces(i)
-          fmt(i, z)
+          fmt(z)
         }
         case (_, DocSpace) :: z => {
-          writer.write(" "); fmt(k + 1, z)
+          writer.write(" "); fmt(z)
         }
         case _ => ()
       }
 
-      fmt(0, List((0, this)))
+      fmt(List((0, this)))
     }
   }
 

--- a/src/main/scala/backends/Document.scala
+++ b/src/main/scala/backends/Document.scala
@@ -35,10 +35,10 @@ object PrettyPrint {
     /**
      * Format this Doc on `writer`.
      */
-    def format(writer: Writer) {
+    def format(writer: Writer): Unit = {
       type FmtState = (Int, Doc)
 
-      def spaces(n: Int) {
+      def spaces(n: Int): Unit = {
         var rem = n
         while (rem >= 16) { writer write "                "; rem -= 16 }
         if (rem >= 8)     { writer write "        "; rem -= 8 }

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -107,7 +107,7 @@ private class VivadoBackendHeader extends VivadoBackend {
   override def emitCmd(c: Command): Doc = emptyDoc
 
   override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match { case FuncDef(id, args, ret, _) =>
-    val as = hsep(args.map(d => emitDecl(d.id, d.typ)), comma)
+    val as = commaSep(args.map(d => emitDecl(d.id, d.typ)))
     emitType(ret) <+> id <> parens(as) <> semi
   }
 

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -10,9 +10,9 @@ import Configuration._
 import CompilerError._
 
 private class VivadoBackend extends CppLike {
-  val CppPreamble: Doc = """
+  val CppPreamble: Doc = text("""
     |#include <ap_int.h>
-  """.stripMargin.trim
+  """.stripMargin.trim)
 
   def unroll(n: Int): Doc = n match {
     case 1 => emptyDoc
@@ -106,9 +106,10 @@ private class VivadoBackend extends CppLike {
 private class VivadoBackendHeader extends VivadoBackend {
   override def emitCmd(c: Command): Doc = emptyDoc
 
-  override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match { case FuncDef(id, args, ret, _) =>
-    val as = commaSep(args.map(d => emitDecl(d.id, d.typ)))
-    emitType(ret) <+> id <> parens(as) <> semi
+  override def emitFunc(func: FuncDef, entry: Boolean): Doc = func match {
+    case FuncDef(id, args, ret, _) =>
+      val as = commaSep(args.map(d => emitDecl(d.id, d.typ)))
+      emitType(ret) <+> id <> parens(as) <> semi
   }
 
   override def emitProg(p: Prog, c: Config) = {

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -22,7 +22,7 @@ private class VivadoBackend extends CppLike {
   def bank(id: Id, banks: List[Int]): String = banks.zipWithIndex.foldLeft(""){
     case (acc, (bank, dim)) =>
       if (bank != 1) {
-        s"${acc}\n#pragma HLS ARRAY_PARTITION variable=$id cyclic factor=$bank dim=${dim + 1}"
+        s"${acc}#pragma HLS ARRAY_PARTITION variable=$id cyclic factor=$bank dim=${dim + 1}"
       } else {
         acc
       }
@@ -42,7 +42,7 @@ private class VivadoBackend extends CppLike {
   }
 
   def emitPipeline(enabled: Boolean): Doc =
-    if (enabled) value(s"#pragma HLS PIPELINE\n") else emptyDoc
+    if (enabled) value(s"#pragma HLS PIPELINE") <> line else emptyDoc
 
   def emitFor(cmd: CFor): Doc =
     text("for") <> emitRange(cmd.range) <+> scope {

--- a/src/main/scala/passes/Checker.scala
+++ b/src/main/scala/passes/Checker.scala
@@ -24,7 +24,7 @@ object Checker {
     /**
      * Top level function called on the AST.
      */
-    def check(p: Prog)
+    def check(p: Prog): Unit
 
     /**
      * Helper functions for checking sequences of the same element.

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -350,7 +350,7 @@ object TypeChecker {
     nEnv -> (pre.getOrElse(len) -> newBank)
   }
 
-  private def checkPipeline(enabled: Boolean, loop: Command, body: Command) {
+  private def checkPipeline(enabled: Boolean, loop: Command, body: Command) = {
     // Only loops without sequencing may be pipelined.
     body match {
       case _: CSeq => if (enabled) {

--- a/src/test/scala/FileTests.scala
+++ b/src/test/scala/FileTests.scala
@@ -1,7 +1,7 @@
 package fuselang
 
 import java.nio.file.{Files, Paths}
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.scalatest.FunSuite
 

--- a/src/test/scala/RunTests.scala
+++ b/src/test/scala/RunTests.scala
@@ -5,7 +5,7 @@ import scala.concurrent._
 import org.scalatest.Tag
 
 import java.nio.file.{Files, Paths, Path}
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import common._
 import Configuration.Config
@@ -65,8 +65,8 @@ class RunTests extends org.scalatest.AsyncFunSuite {
   for (file <- Files.newDirectoryStream(shouldRun).asScala
        if file.toString.matches(srcFilePattern)) {
          test(file.toString, SlowTest) {
-           val dataPath = Paths.get(file + ".data.json")
-           val outFile = tmpDir.resolve(file.getFileName + ".cpp")
+           val dataPath = Paths.get(file.toString + ".data.json")
+           val outFile = tmpDir.resolve(file.getFileName.toString + ".cpp")
 
            // Make sure data file is present
            assert(

--- a/tools/vim/syntax/fuse.vim
+++ b/tools/vim/syntax/fuse.vim
@@ -10,7 +10,7 @@ syn keyword fuseConstant true false
 syn keyword fuseType ubit bit float bool bank double
 
 " Control structures
-syn keyword fuseKeyword if for while import
+syn keyword fuseKeyword if else for while import
 " Binding variables
 syn keyword fuseKeyword let def decl extern as decor
 syn keyword fuseKeyword unroll record combine


### PR DESCRIPTION
- Add Document class from deprecated scala.text into source.
- Will allow for 2.13 migration and usage of scala.js.