### PR TITLE
Implement pretty printer for Dahlia AST

### DIFF
--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -5,8 +5,18 @@ import java.nio.file.Path
 
 import common._
 import Configuration._
+import Syntax._
 
 object Compiler {
+
+  def showDebug(ast: Prog, pass: String, c: Config): Unit = {
+    if (c.passDebug) {
+      val top = ("=" * 15) + pass + ("=" * 15)
+      println(top)
+      println(Pretty.emitProg(ast)(true).trim)
+      println("=" * top.length)
+    }
+  }
 
   def toBackend(str: BackendOption): fuselang.backend.Backend = str match {
     case Vivado => backend.VivadoBackend
@@ -16,10 +26,10 @@ object Compiler {
 
   def compileStringWithError(prog: String, c: Config = emptyConf) = {
     val ast = FuseParser.parse(prog)
-    typechecker.CapabilityChecker.check(ast)
-    typechecker.TypeChecker.typeCheck(ast)
-    passes.BoundsChecker.check(ast);
-    val rast = passes.RewriteView.rewriteProg(ast)
+    typechecker.CapabilityChecker.check(ast); showDebug(ast, "Capability Checking", c)
+    typechecker.TypeChecker.typeCheck(ast); showDebug(ast, "Type Checking", c)
+    passes.BoundsChecker.check(ast);  // Doesn't modify the AST.
+    val rast = passes.RewriteView.rewriteProg(ast); showDebug(rast, "Rewrite Views", c)
     toBackend(c.backend).emit(rast, c)
   }
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -53,6 +53,10 @@ object Main {
       .action((_, c) => c.copy(header = true))
       .text("Generate header file instead of code. Default: false.")
 
+    opt[Unit]("pass-debug")
+      .action((_, c) => c.copy(passDebug = true))
+      .text("Show the AST after every compiler pass. Default: false.")
+
     cmd("run")
       .action((_, c) => c.copy(mode = Run, backend = Cpp))
       .text("Generate a runnable object file. Assumes GCC and required headers are available. Implies mode=c++.")

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -1,10 +1,10 @@
 package fuselang.backend
-import PrettyPrint.Doc._
-import PrettyPrint.Doc
 
 import fuselang.common._
 import Syntax._
 import CompilerError._
+import PrettyPrint.Doc._
+import PrettyPrint.Doc
 
 object Cpp {
   /**
@@ -22,7 +22,6 @@ object Cpp {
 
     val defaultIndent = 2
 
-    def commaSep(docs: List[Doc]) = hsep(docs, comma <> space)
 
     /**
      * Helper to generate a variable declaration with an initial value.
@@ -80,9 +79,6 @@ object Cpp {
       semi
 
     implicit def IdToString(id: Id): Doc = value(id.v)
-
-    def scope(doc: Doc): Doc =
-      lbrace <> nest(emptyDoc <@> doc, defaultIndent) <@> rbrace
 
     def emitBaseInt(v: Int, base: Int): String = base match {
       case 8 => s"0${Integer.toString(v, 8)}"

--- a/src/main/scala/backends/CppRunnable.scala
+++ b/src/main/scala/backends/CppRunnable.scala
@@ -1,13 +1,13 @@
 package fuselang.backend
 
 import Cpp._
-import PrettyPrint.Doc
-import PrettyPrint.Doc._
 
 import fuselang.common._
 import Syntax._
 import Configuration._
 import CompilerError._
+import PrettyPrint.Doc
+import PrettyPrint.Doc._
 
 /**
  * Same as [[fuselang.backend.VivadoBackend]] except this creates a main
@@ -21,7 +21,7 @@ private class CppRunnable extends CppLike {
     case _:TVoid => text("void")
     case _:TBool => text("bool")
     case _:TIndex => text("int")
-    case _:TStaticInt => throw Impossible("TStaticInt type should not exist")    
+    case _:TStaticInt => throw Impossible("TStaticInt type should not exist")
     case TSizedInt(_, un) => text(if (un) "unsigned int" else "int")
     case _:TFloat => text("float")
     case _:TDouble | _:TFixed => text("double")

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -1,13 +1,13 @@
 package fuselang.backend
 
 import Cpp._
-import PrettyPrint.Doc
-import PrettyPrint.Doc._
 
 import fuselang.common._
 import Syntax._
 import Configuration._
 import CompilerError._
+import PrettyPrint.Doc
+import PrettyPrint.Doc._
 
 private class VivadoBackend extends CppLike {
   val CppPreamble: Doc = text("""
@@ -81,12 +81,12 @@ private class VivadoBackend extends CppLike {
   def emitType(typ: Type): Doc = typ match {
     case _:TVoid => text("void")
     case _:TBool | _:TIndex => text("int")
-    case _:TStaticInt => throw Impossible("TStaticInt type should not exist")    
+    case _:TStaticInt => throw Impossible("TStaticInt type should not exist")
     case _:TFloat => text("float")
     case _:TDouble => text("double")
-    case _:TRational => throw Impossible("Rational type should not exist")    
+    case _:TRational => throw Impossible("Rational type should not exist")
     case TSizedInt(s, un) => text(if (un) s"ap_uint<$s>" else s"ap_int<$s>")
-    case TFixed(t,i,un) => text(if (un) s"ap_ufixed<$t,$i>" else s"ap_fixed<$t,$i>") 
+    case TFixed(t,i,un) => text(if (un) s"ap_ufixed<$t,$i>" else s"ap_fixed<$t,$i>")
     case TArray(typ, _) => emitType(typ)
     case TRecType(n, _) => text(n.toString)
     case _:TFun => throw Impossible("Cannot emit function types")

--- a/src/main/scala/backends/futil/FutilAst.scala
+++ b/src/main/scala/backends/futil/FutilAst.scala
@@ -1,6 +1,6 @@
 package fuselang.backend.futil
 
-import fuselang.backend.PrettyPrint.Doc
+import fuselang.common.PrettyPrint.Doc
 import Doc._
 
 object Futil {

--- a/src/main/scala/common/Configuration.scala
+++ b/src/main/scala/common/Configuration.scala
@@ -24,6 +24,7 @@ object Configuration {
     mode: Mode = Compile,                 // Compilation mode
     compilerOpts: List[String] = List(),  // Extra options to the generateExec Compiler
     header: Boolean = false,              // Generate a header
+    passDebug: Boolean = false,           // Show AST after every state
     logLevel: scribe.Level = scribe.Level.Info
   )
 

--- a/src/main/scala/common/Document.scala
+++ b/src/main/scala/common/Document.scala
@@ -2,7 +2,7 @@
  * Lightweight library from the deprecated scala.text distribution.
  */
 
-package fuselang.backend
+package fuselang.common
 
 import java.io.Writer
 
@@ -84,6 +84,7 @@ object PrettyPrint {
 
     /** Common primitives */
     def semi: Doc = text(";")
+    def colon: Doc = text(":")
     def comma: Doc = text(",")
     def dot: Doc = text(".")
     def equal: Doc = text("=")
@@ -93,26 +94,31 @@ object PrettyPrint {
     /** A nested Doc, which will be indented as specified. */
     def nest(d: Doc, i: Int): Doc = DocNest(i, d)
 
-    def folddoc(ds: Seq[Doc], f: (Doc, Doc) => Doc) =
+    def folddoc(ds: Iterable[Doc], f: (Doc, Doc) => Doc) =
       if (ds.isEmpty) emptyDoc
       else ds.tail.foldLeft(ds.head)(f)
 
     /** Builder functions */
-    def hsep(ds: Seq[Doc], sep: Doc): Doc =
+    def hsep(ds: Iterable[Doc], sep: Doc): Doc =
       folddoc(ds, (_ <> sep <> _))
 
-    def ssep(ds: Seq[Doc], sep: Doc): Doc =
+    def ssep(ds: Iterable[Doc], sep: Doc): Doc =
       folddoc(ds, (_ <> sep <> _))
 
-    def hsep(ds: Seq[Doc]): Doc =
+    def hsep(ds: Iterable[Doc]): Doc =
       folddoc(ds, (_ <+> _))
 
-    def vsep(ds: Seq[Doc]): Doc =
+    def vsep(ds: Iterable[Doc]): Doc =
       folddoc(ds, (_ <@> _))
 
     def enclose(l: Doc, d: Doc, r: Doc) = l <> d <> r
 
     def surround(d: Doc, s: Doc) = enclose(s, d, s)
+
+    def commaSep(docs: List[Doc]) = hsep(docs, comma <> space)
+
+    def scope(doc: Doc, indent: Int = 2): Doc =
+      lbrace <> nest(emptyDoc <@> doc, indent) <@> rbrace
 
     /** Common functions **/
 

--- a/src/main/scala/common/Pretty.scala
+++ b/src/main/scala/common/Pretty.scala
@@ -1,0 +1,130 @@
+package fuselang.common
+
+import scala.language.implicitConversions
+
+import Syntax._
+import PrettyPrint.Doc
+import PrettyPrint.Doc._
+
+object Pretty {
+
+  def emitProg(p: Prog)(implicit debug: Boolean): String = {
+    val layout = vsep(p.includes.map(emitInclude)) <@>
+    vsep(p.defs.map(emitDef)) <@>
+    vsep(p.decors.map(d => text(d.value))) <@>
+    vsep(p.decls.map(d => text("decl") <+> emitDecl(d) <> semi)) <@>
+    emitCmd(p.cmd)
+
+    layout.pretty
+  }
+
+  def emitInclude(incl: Include)(implicit debug: Boolean): Doc = {
+    text("import") <+> text(incl.name) <+> scope(vsep(incl.defs.map(emitDef)))
+  }
+
+  def emitDef(defi: Definition)(implicit debug: Boolean): Doc = defi match {
+    case FuncDef(id, args, ret, bodyOpt) => {
+      text("def") <+> id <> parens(ssep(args.map(emitDecl), comma <> space)) <+>
+      emitTyp(ret) <> bodyOpt.map(emitCmd).getOrElse(semi)
+    }
+    case RecordDef(name, fields) => {
+      text("record") <+> name <+> scope(vsep(fields.map({
+        case (id, typ) => id <> colon <+> emitTyp(typ) <> semi
+      })))
+    }
+  }
+
+  def emitDecl(d: Decl): Doc = emitId(d.id)(false) <> colon <+> emitTyp(d.typ)
+
+  def emitConsume(ann: Annotations.Consumable): Doc = ann match {
+    case Annotations.ShouldConsume => text("consume")
+    case Annotations.SkipConsume => text("skip")
+  }
+
+  implicit def emitId(id: Id)(implicit debug: Boolean): Doc = {
+    if (debug) brackets(value(id.v) <> colon <+> id.typ.map(emitTyp).getOrElse(emptyDoc))
+    else value(id.v)
+  }
+
+  def emitTyp(t: Type): Doc = text(t.toString)
+
+  def emitBaseInt(v: Int, base: Int): String = base match {
+    case 8 => s"0${Integer.toString(v, 8)}"
+    case 10 => v.toString
+    case 16 => s"0x${Integer.toString(v, 16)}"
+  }
+
+  implicit def emitExpr(e: Expr)(implicit debug: Boolean): Doc = e match {
+    case ECast(e, typ) => parens(e <+> text("as") <+> emitTyp(typ))
+    case EApp(fn, args) => fn <> parens(commaSep(args.map(emitExpr)))
+    case EInt(v, base) => value(emitBaseInt(v, base))
+    case ERational(d) => value(d)
+    case EBool(b) => value(if(b) 1 else 0)
+    case EVar(id) => value(id)
+    case EBinop(op, e1, e2) => parens(e1 <+> text(op.toString) <+> e2)
+    case acc@EArrAccess(id, idxs) => {
+      val doc = id <> ssep(idxs.map(idx => brackets(emitExpr(idx))), emptyDoc)
+      if (debug) brackets(doc <> colon <+> acc.consumable.map(emitConsume).getOrElse(emptyDoc))
+      else doc
+    }
+    case EArrLiteral(idxs) => braces(commaSep(idxs.map(idx => emitExpr(idx))))
+    case ERecAccess(rec, field) => rec <> dot <> field
+    case ERecLiteral(fs) => scope {
+      commaSep(fs.toList.map({ case (id, expr) => id <+> equal <+> expr <> semi }))
+    }
+  }
+
+  def emitRange(range: CRange)(implicit debug: Boolean): Doc = {
+    val CRange(id, s, e, u) = range
+
+    parens(text("let") <+> id <+> equal <+> value(s) <+> text("..") <+> value(e)) <>
+    (if (u > 1) space <> text("unroll") <+> value(u) else emptyDoc)
+  }
+
+  def emitView(view: View)(implicit debug: Boolean): Doc = {
+    val View(suf, pre, sh) = view
+
+    val sufDoc = suf match {
+      case Aligned(f, e) => value(f) <+> text("*") <+> e
+      case Rotation(e) => e <+> text("!")
+    }
+
+    sufDoc <+> colon <>
+      pre.map(p => space <> text("+") <+> value(p)).getOrElse(emptyDoc) <>
+      sh.map(sh => space <> text("bank") <+> value(sh)).getOrElse(emptyDoc)
+  }
+
+  implicit def emitCmd(c: Command)(implicit debug: Boolean): Doc = c match {
+    case CPar(c1, c2) => c1 <@> c2
+    case CSeq(c1, c2) => c1 <@> text("---") <@> c2
+    case CLet(id, typ, e) =>
+      text("let") <+> id <>
+        typ.map(space <> colon <+> emitTyp(_)).getOrElse(emptyDoc) <>
+        e.map(space <> equal <+> emitExpr(_)).getOrElse(emptyDoc) <> semi
+    case CIf(cond, cons, alt) => {
+      text("if") <+> parens(cond) <+> scope (cons) <> (alt match {
+        case CEmpty => emptyDoc
+        case _ => space <> text("else") <+> scope(alt)
+      })
+    }
+    case CFor(r, pipe, par, com) =>
+      text("for") <+> emitRange(r) <>
+        (if (pipe) space <> text("pipeline") else emptyDoc) <+>
+        scope(emitCmd(par)) <+> text("combine") <+> scope(emitCmd(com))
+    case CWhile(cond, pipe, body) =>
+      text("while") <+> parens(cond) <>
+        (if (pipe) space <> text("pipeline") else emptyDoc) <+> scope(emitCmd(body))
+    case CDecorate(dec) => value(dec)
+    case CUpdate(lhs, rhs) => lhs <+> equal <+> rhs <> semi
+    case CReduce(rop, lhs, rhs) => lhs <+> text(rop.toString) <+> rhs <> semi
+    case CReturn(e) => text("return") <+> e <> semi
+    case CExpr(e) => e <> semi
+    case CEmpty => emptyDoc
+    case CView(view, arr, dims) =>
+      text("view") <+> view <+> equal <+> arr <+>
+        ssep(dims.map(v => brackets(emitView(v))), emptyDoc) <> semi
+    case CSplit(vId, arrId, factors) =>
+      text("split") <+> vId <+> equal <+> arrId <>
+        ssep(factors.map(factor => brackets(text("by") <+> value(factor))), emptyDoc)
+  }
+}


### PR DESCRIPTION
- Add `--pass-debug` to show AST state after a pass. The flag also displays mutable AST information like `Consumable` annotations and inferred types for debugging.