### PR TITLE
fixed loop checker

### DIFF
--- a/src/main/scala/passes/LoopCheck.scala
+++ b/src/main/scala/passes/LoopCheck.scala
@@ -67,14 +67,9 @@ object LoopChecker {
     }
     // Helper functions for ScopeManager
     def withScope(resources: Int)(inScope: LEnv => LEnv): LEnv = {
-      inScope(this.addScope(resources)) match {
-        case env:LEnv => env.endScope(resources)
-      }
-    }
-    def withScope(loop: Boolean, resources: Int)(inScope: LEnv => LEnv): LEnv = {
-      if (loop == false){
-          inScope(this.addIfScope) match {
-            case env:LEnv => env.endIfScope
+      if (resources == 1){
+          inScope(this.addNameScope) match {
+            case env:LEnv => env.endNameScope
           }
       }else{
           inScope(this.addScope(resources)) match {
@@ -98,10 +93,10 @@ object LoopChecker {
       }
       outerenv
     }
-    def addIfScope = {
+    def addNameScope = {
       LEnv(stateMap, nameMap.addScope)
     }
-    def endIfScope = {
+    def endNameScope = {
       val nmap = nameMap.endScope.get._2
       LEnv(stateMap, nmap)
     }
@@ -171,10 +166,10 @@ object LoopChecker {
         e1.withScope(1)(env => checkC(body)(env))
       }
       case (CIf(cond, c1, c2), e) => {
-        e.withScope(false, 1)( someScope =>{
+        e.withScope( someScope =>{
           val nEnv = checkE(cond)(someScope)
-          val e1 = nEnv.withScope(false, 1)(checkC(c1)(_))
-          val e2 = nEnv.withScope(false, 1)(checkC(c2)(_))
+          val e1 = nEnv.withScope(checkC(c1)(_))
+          val e2 = nEnv.withScope(checkC(c2)(_))
           e1 merge e2
         })
       }


### PR DESCRIPTION
This is the true loopfix. There is something wrong with nameMap in the last version.

NameMap need addScope and endScope methods within both `if` scopes and loop scopes (`while` and `for`). StateMap does not for `if` statements, but for loops it does.
That makes both last pull request of fixing (which does not create scope for nameMap at an `if` statement) and the old loop checker both wrong (which create scope for both nameMap and stateMap at an `if` statement).