### PR TITLE
quick fix to indexing of loop checker

### DIFF
--- a/src/main/scala/common/ScopeMap.scala
+++ b/src/main/scala/common/ScopeMap.scala
@@ -19,7 +19,7 @@ object ScopeMap {
         .mkString(" => ")
 
     def head = mapList.head
-
+    def length = mapList.length - 1
     /**
      * Returns first occurance of the binding for key in the scope chain.
      */

--- a/src/main/scala/passes/LoopCheck.scala
+++ b/src/main/scala/passes/LoopCheck.scala
@@ -115,12 +115,11 @@ object LoopChecker {
       outerenv
     }
     def addNameScope = {
-      LEnv(stateMap, nameMap.addScope, exprMap.addScope)
+      LEnv(stateMap, nameMap.addScope, exprMap)
     }
     def endNameScope = {
       val nmap = nameMap.endScope.get._2
-      val emap = exprMap.endScope.get._2
-      LEnv(stateMap, nmap, emap)
+      LEnv(stateMap, nmap, exprMap)
     }
 
     def mergeHelper(k: Id, v1:  Option[States], v2: Option[States], env: LEnv): LEnv = (v1, v2) match {

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -793,9 +793,9 @@ class TypeCheckerSpec extends FunSpec {
     it("use after define in an unrolled loop is not allowed") {
       assertThrows[LoopDepSequential] {
         typeCheck("""
-          decl a: bit<32>[10 bank 5];
-          for (let i = 0..10) unroll 5 {
-            let x = a[i]
+          let a: bit<32>{2}[10];
+          for (let i = 0..10) unroll 2 {
+            let x = a[i+1]
             ---
             a[i] := 1
           }


### PR DESCRIPTION
Now if the index is completely the same at the dimension requires unrolling, loop checker says there is not have cross loop dependency, but it is not smart enough to check view.