### PR TITLE
fix scoping for dependent loops

### DIFF
--- a/src/main/scala/passes/DependentLoops.scala
+++ b/src/main/scala/passes/DependentLoops.scala
@@ -40,7 +40,14 @@ object DependentLoops {
     loopVars: Set[Id],
     depVars: Set[Id]
   ) extends ScopeManager[DepEnv] {
-    def withScope(inScope: DepEnv => DepEnv): DepEnv = inScope(this)
+    def withScope(inScope: DepEnv => DepEnv): DepEnv = {
+      inScope(this)
+    }
+
+    def forgetScope(inScope: DepEnv => DepEnv): DepEnv = {
+      inScope(this)
+      this
+    }
 
     def merge(that: DepEnv): DepEnv = DepEnv(this.loopVars ++ that.loopVars, this.depVars ++ that.depVars)
 
@@ -84,11 +91,11 @@ object DependentLoops {
     override def myCheckC: PF[(Command, Env), Env] = {
       case (CFor(range, _, par, _), env) => {
         if (range.u > 1) {
-          env.withScope(e1 =>
+          env.forgetScope(e1 =>
             checkC(par)(e1.addLoopVar(range.iter))
           )
         } else {
-          env.withScope(e1 =>
+          env.forgetScope(e1 =>
             checkC(par)(e1)
           )
         }


### PR DESCRIPTION
I wasn't able to get the ScopedSets working correctly, so I just made a much simpler change. Writing this I realized that this doesn't work in all cases.

this throws an error but shouldn't
```c
let foo: float[2];
for (let j = 0..2) unroll 2 {
  let y: bit<100> = j + 1;
  for (let i = 0..2) unroll 2 {
    y := 3;
  }
  for (let i = 0..2) unroll 2 {
    foo[y];
  }
}
```