### PR TITLE
Implement internal-only physical accesses

### DIFF
--- a/src/main/scala/Compiler.scala
+++ b/src/main/scala/Compiler.scala
@@ -39,7 +39,7 @@ object Compiler {
   }
 
   def codegen(ast: Prog, c: Config = emptyConf) = {
-    val rast = passes.RewriteView.rewriteProg(ast);
+    val rast = passes.RewriteView.rewrite(ast);
     showDebug(rast, "Rewrite Views", c)
 
     // Perform program lowering if needed.

--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -99,6 +99,8 @@ object Cpp {
       case EArrAccess(id, idxs) =>
         id <> ssep(idxs.map(idx => brackets(emitExpr(idx))), emptyDoc)
       case EArrLiteral(idxs) => braces(commaSep(idxs.map(idx => emitExpr(idx))))
+      case _: EPhysAccess =>
+        throw NotImplemented("Physical access code gen for cpp-like backends.")
       case ERecAccess(rec, field) => rec <> dot <> field
       case ERecLiteral(fs) =>
         scope {

--- a/src/main/scala/common/Checker.scala
+++ b/src/main/scala/common/Checker.scala
@@ -76,6 +76,8 @@ object Checker {
       case ECast(e, _) => checkE(e)
       case ERecAccess(rec, _) => checkE(rec)
       case EArrAccess(_, idxs) => checkESeq(idxs)
+      case EPhysAccess(_, bankIdxs) =>
+        checkESeq(bankIdxs.flatMap({ case (bank, idx) => List(bank, idx) }))
     }
 
     def checkLVal(e: Expr)(implicit env: Env): Env = checkE(e)

--- a/src/main/scala/common/EnvHelpers.scala
+++ b/src/main/scala/common/EnvHelpers.scala
@@ -49,4 +49,12 @@ object EnvHelpers {
     def get(k: K): Option[V]
   }
 
+  /**
+    * Definition of a trivial environment that doesn't track any
+    * information.
+    */
+  final case class UnitEnv() extends ScopeManager[UnitEnv] {
+    def merge(that: UnitEnv) = this
+  }
+
 }

--- a/src/main/scala/common/Pretty.scala
+++ b/src/main/scala/common/Pretty.scala
@@ -72,6 +72,22 @@ object Pretty {
         )
       else doc
     }
+    case acc @ EPhysAccess(id, idxs) => {
+      val doc = id <>
+        ssep(
+          idxs.map({
+            case (bank, idx) =>
+              braces(emitExpr(bank)) <> brackets(emitExpr(idx))
+          }),
+          emptyDoc
+        )
+
+      if (debug)
+        brackets(
+          doc <> colon <+> acc.consumable.map(emitConsume).getOrElse(emptyDoc)
+        )
+      else doc
+    }
     case EArrLiteral(idxs) => braces(commaSep(idxs.map(idx => emitExpr(idx))))
     case ERecAccess(rec, field) => rec <> dot <> field
     case ERecLiteral(fs) =>

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -126,7 +126,7 @@ object Syntax {
   case class EArrAccess(id: Id, idxs: List[Expr])
       extends Expr
       with ConsumableAnnotation
-  case class EPhsAccess(id: Id, bankIdxs: List[(Expr, Expr)])
+  case class EPhysAccess(id: Id, bankIdxs: List[(Expr, Expr)])
       extends Expr
       with ConsumableAnnotation
   case class EArrLiteral(idxs: List[Expr]) extends Expr

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -126,6 +126,9 @@ object Syntax {
   case class EArrAccess(id: Id, idxs: List[Expr])
       extends Expr
       with ConsumableAnnotation
+  case class EPhsAccess(id: Id, bankIdxs: List[(Expr, Expr)])
+      extends Expr
+      with ConsumableAnnotation
   case class EArrLiteral(idxs: List[Expr]) extends Expr
   case class ERecAccess(rec: Expr, fieldName: Id) extends Expr
   case class ERecLiteral(fields: Map[Id, Expr]) extends Expr

--- a/src/main/scala/passes/BoundsCheck.scala
+++ b/src/main/scala/passes/BoundsCheck.scala
@@ -16,18 +16,11 @@ object BoundsChecker {
 
   def check(p: Prog) = BCheck.check(p)
 
-  // Bounds checker environment doesn't need to track any information. Empty
-  // environment that just runs the commands.
-  private case class BEnv() extends ScopeManager[BEnv] {
-    // Neither environment contains anything.
-    def merge(that: BEnv): BEnv = this
-  }
-
   private final case object BCheck extends PartialChecker {
 
-    type Env = BEnv
+    type Env = UnitEnv
 
-    val emptyEnv = BEnv()
+    val emptyEnv = UnitEnv()
 
     /**
       * Given a view with a known prefix length, check if it **might** cause an

--- a/src/main/scala/passes/LowerForLoops.scala
+++ b/src/main/scala/passes/LowerForLoops.scala
@@ -3,6 +3,7 @@ package fuselang.passes
 import scala.{PartialFunction => PF}
 import fuselang.common._
 import Transformer._
+import EnvHelpers._
 import Syntax._
 import CompilerError._
 

--- a/src/main/scala/passes/RewriteView.scala
+++ b/src/main/scala/passes/RewriteView.scala
@@ -1,9 +1,12 @@
 package fuselang.passes
 
+import scala.{PartialFunction => PF}
 import fuselang.common._
 import Syntax._
 import CodeGenHelpers._
 import CompilerError._
+import Transformer._
+import EnvHelpers._
 
 import fuselang.Utils.RichOption
 
@@ -19,83 +22,74 @@ import fuselang.Utils.RichOption
   * [[fuselang.StateHelper.State]].
   */
 object RewriteView {
-  import StateHelper._
 
-  /**
-    * Represents a mapping from view ids to a function that takes all dimension
-    * expressions returns a new array access expression
-    */
-  type Env = Map[Id, List[Expr] => Expr]
+  def rewrite = ViewRewriter.rewrite _
 
-  private def rewriteExpr(e: Expr): State[Env, Expr] = e match {
-    case EVar(_) | EInt(_, _) | ERational(_) | EBool(_) => State.unit(e)
-    case erec @ ERecAccess(rec, _) =>
-      for {
-        recn <- rewriteExpr(rec)
-      } yield erec.copy(rec = recn)
-    case ec @ ECast(e, _) =>
-      for {
-        en <- rewriteExpr(e)
-      } yield ec.copy(e = en)
-    case eb @ EBinop(_, e1, e2) =>
-      for {
-        e1n <- rewriteExpr(e1)
-        e2n <- rewriteExpr(e2)
-      } yield eb.copy(e1 = e1n, e2 = e2n)
-    case eaa @ EArrAccess(arrId, idxs) =>
-      for {
-        idxsn <- State.mapList(rewriteExpr)(idxs)
-        state <- State.get
-        ret <- if (state.contains(arrId)) rewriteExpr(state(arrId)(idxsn))
-        else State.unit[Env, Expr](eaa.copy(idxs = idxsn))
-      } yield ret
-    case app @ EApp(_, args) =>
-      for {
-        argsn <- State.mapList(rewriteExpr)(args)
-      } yield app.copy(args = argsn)
-    case ERecLiteral(fs) =>
-      for {
-        fsn <- State.mapMap(rewriteExpr)(fs)
-      } yield ERecLiteral(fsn)
-    case EArrLiteral(idxs) =>
-      for {
-        idxsn <- State.mapList(rewriteExpr)(idxs)
-      } yield EArrLiteral(idxsn)
-  }
+  private final object ViewRewriter extends PartialTranformer {
+    case class ViewEnv(map: Map[Id, List[Expr] => Expr])
+        extends ScopeManager[ViewEnv]
+        with Tracker[Id, List[Expr] => Expr, ViewEnv] {
+      def merge(that: ViewEnv) = {
+        if (this.map.keys != that.map.keys)
+          throw Impossible("Tried to merge ViewEnvs with different keys.")
+        this
+      }
 
-  private def genViewAccessExpr(view: View, idx: Expr): Expr =
-    view.suffix match {
-      case Aligned(factor, e2) => (EInt(factor) * e2) + idx
-      case Rotation(e) => e + idx
+      def get(arrId: Id) = this.map.get(arrId)
+
+      def add(arrId: Id, func: List[Expr] => Expr) =
+        ViewEnv(this.map + (arrId -> func))
     }
 
-  private def splitAccessExpr(
-      i: Expr,
-      j: Expr,
-      arrBank: Int,
-      viewBank: Int
-  ): Expr =
-    (i * EInt(viewBank)) +
-      ((j / EInt(viewBank)) * EInt(arrBank)) +
-      (j % EInt(viewBank))
+    type Env = ViewEnv
+    val emptyEnv = ViewEnv(Map())
 
-  private def rewriteC(c: Command): State[Env, Command] = c match {
-    case CPar(c1, c2) =>
-      for {
-        c1n <- rewriteC(c1)
-        c2n <- rewriteC(c2)
-      } yield CPar(c1n, c2n)
-    case CSeq(c1, c2) =>
-      for {
-        c1n <- rewriteC(c1)
-        c2n <- rewriteC(c2)
-      } yield CSeq(c1n, c2n)
-    case l @ CLet(_, _, e) =>
-      for {
-        en <- State.mapOpt(rewriteExpr)(e)
-      } yield l.copy(e = en)
-    case CView(id, arrId, dims) =>
-      State { env =>
+    private def genViewAccessExpr(view: View, idx: Expr): Expr =
+      view.suffix match {
+        case Aligned(factor, e2) => (EInt(factor) * e2) + idx
+        case Rotation(e) => e + idx
+      }
+
+    private def splitAccessExpr(
+        i: Expr,
+        j: Expr,
+        arrBank: Int,
+        viewBank: Int
+    ): Expr = {
+      (i * EInt(viewBank)) +
+        ((j / EInt(viewBank)) * EInt(arrBank)) +
+        (j % EInt(viewBank))
+    }
+
+    override def myRewriteE: PF[(Expr, Env), (Expr, Env)] = {
+      case (acc @ EArrAccess(arrId, idxs), env) => {
+        // Rewrite the indexing expressions
+        val (nIdxs, nEnv) = super.rewriteESeq(idxs)(env)
+        val rewrite = nEnv.get(arrId)
+        if (rewrite.isDefined) {
+          rewriteE((rewrite.get)(nIdxs.toList))(nEnv)
+        } else {
+          acc.copy(idxs = nIdxs.toList) -> nEnv
+        }
+      }
+      case (acc @ EPhysAccess(arrId, bankIdxs), env) => {
+        // Rewrite the indexing expressions
+        val (nBankIdxs, nEnv) = super.rewriteSeqWith({
+          case ((bank, idx), env) =>
+            val (nBank, env1) = super.rewriteE(bank)(env)
+            val (nIdx, env2) = super.rewriteE(idx)(env1)
+            (nBank, nIdx) -> env2
+        }: ((Expr, Expr), Env) => ((Expr, Expr), Env))(bankIdxs)(env)
+
+        if (nEnv.get(arrId).isDefined) {
+          throw NotImplemented("Rewriting physical accesses on views.")
+        }
+        acc.copy(bankIdxs = nBankIdxs.toList) -> nEnv
+      }
+    }
+
+    override def myRewriteC: PF[(Command, Env), (Command, Env)] = {
+      case (CView(id, arrId, dims), env) => {
         val f = (es: List[Expr]) =>
           EArrAccess(
             arrId,
@@ -105,10 +99,9 @@ object RewriteView {
                   genViewAccessExpr(view, idx)
               })
           )
-        (CEmpty, env + (id -> f))
+        (CEmpty, env.add(id, f))
       }
-    case CSplit(id, arrId, factors) =>
-      State { env =>
+      case (c @ CSplit(id, arrId, factors), env) => {
         val arrBanks = arrId.typ
           .getOrThrow(Impossible(s"$arrId is missing type in $c")) match {
           case TArray(_, dims, _) => dims.map(_._2)
@@ -130,156 +123,15 @@ object RewriteView {
             })
           EArrAccess(arrId, idxs)
         }
-        (CEmpty, env + (id -> f))
+        (CEmpty, env.add(id, f))
       }
-    case CIf(e1, c1, c2) =>
-      for {
-        e1n <- rewriteExpr(e1)
-        c1n <- rewriteC(c1)
-        c2n <- rewriteC(c2)
-      } yield CIf(e1n, c1n, c2n)
-    case cf @ CFor(_, _, c1, c2) =>
-      for {
-        c1n <- rewriteC(c1)
-        c2n <- rewriteC(c2)
-      } yield cf.copy(par = c1n, combine = c2n)
-    case cw @ CWhile(_, _, c) =>
-      for {
-        cn <- rewriteC(c)
-      } yield cw.copy(body = cn)
-    case _: CDecorate => State.unit(c)
-    case CUpdate(e1, e2) =>
-      for {
-        e1n <- rewriteExpr(e1)
-        e2n <- rewriteExpr(e2)
-      } yield CUpdate(e1n, e2n)
-    case cr @ CReduce(_, e1, e2) =>
-      for {
-        e1n <- rewriteExpr(e1)
-        e2n <- rewriteExpr(e2)
-      } yield cr.copy(lhs = e1n, rhs = e2n)
-    case CExpr(exp) =>
-      for {
-        e1n <- rewriteExpr(exp)
-      } yield CExpr(e1n)
-    case CReturn(exp) =>
-      for {
-        e1n <- rewriteExpr(exp)
-      } yield CReturn(e1n)
-    case CEmpty => State.unit(c)
-  }
-
-  def rewriteProg(p: Prog): Prog = {
-    val emptyEnv = Map[Id, List[Expr] => Expr]()
-    val fs = p.defs.map(defi =>
-      defi match {
-        case fdef @ FuncDef(_, _, _, bOpt) =>
-          fdef.copy(bodyOpt = bOpt.map(b => rewriteC(b)(emptyEnv)._1))
-        case _ => defi
-      }
-    )
-    val cmdn = rewriteC(p.cmd)(emptyEnv)._1
-    p.copy(defs = fs, cmd = cmdn)
-  }
-}
-
-private object StateHelper {
-
-  /**
-    * Monadic implementation of `State`. The type variable [[S]] refers to
-    * an abstract state that is carried through the computations over [[A]].
-    *
-    * The parameter [[computation]] refers to the entire computation collected
-    * upto this point. The functions [[map]] and [[flatMap]] allow us to build
-    * up other computations over the current one.
-    *
-    * Extending AnyVal is an optimization to reduce the overhead of this case
-    * class.
-    *
-    * For more funky examples, read this series of blog posts: http://eed3si9n.com/learning-scalaz/State.html
-    *
-    */
-  case class State[S, A](computation: S => (A, S)) extends AnyVal {
-
-    /**
-      * Run this computation with the initial state [[initState]] and return
-      * the answer with the final state.
-      */
-    def apply(initState: S): (A, S) = computation(initState)
-
-    /**
-      * Transform the result using the function [[f]]. When the this monad is
-      * run, it will first run [[computation]] and apply [[f]] to the result.
-      */
-    def map[B](f: A => B) = State[S, B] { state =>
-      val (value, newState) = computation(state)
-      (f(value), newState)
     }
 
-    /**
-      * Merge another computation [[f]] into this one. This is done by first
-      * running this computation and then passing the result and the state to
-      * the next computation.
-      */
-    def flatMap[B](f: A => State[S, B]) = State[S, B] { state =>
-      val (value, newState) = computation(state)
-      f(value)(newState)
-    }
-
-  }
-
-  object State {
-    def unit[S, A](a: A): State[S, A] = State { state => (a, state) }
-
-    /**
-      * Type theory note: The code for foldLeft is repetitive. There might
-      * be a generic notion of a `lift` function that can turn `map` on a
-      * collection into a `map` over the monadic version of that collection.
-      *
-      * Formally:
-      *
-      * lift: (C[A] -> (A -> B) -> C[B]) -> (M[C[A]] -> (A -> B) -> M[C[B]])
-      *
-      * where `C` and `M` are monads (being a functor might suffice).
-      * Unfortunately, implementing this in scala requires enabling the
-      * `higherKinds` features.
-      *
-      * Instead, we just manually define these over List and Map which are the
-      * two commonly used collections in our AST.
-      *
-      */
-    def mapMap[S, K, V1, V2](
-        f: V1 => State[S, V2]
-    )(map: Map[K, V1]): State[S, Map[K, V2]] =
-      mapList[S, (K, V1), (K, V2)]({
-        case (k, v) => f(v).map(v2 => k -> v2)
-      })(map.toList).map(_.toMap)
-
-    def mapList[S, A, B](f: A => State[S, B])(es: List[A]): State[S, List[B]] =
-      es match {
-        case Nil => State.unit(Nil)
-        case hd :: tl =>
-          for {
-            hdn <- f(hd)
-            tln <- mapList(f)(tl)
-          } yield hdn :: tln
-      }
-
-    def mapOpt[S, A, B](
-        f: A => State[S, B]
-    )(eOpt: Option[A]): State[S, Option[B]] =
-      eOpt match {
-        case None => State.unit(None)
-        case Some(e) =>
-          for {
-            en <- f(e)
-          } yield Some(en)
-      }
-
-    /**
-      * Return the current state as a value
-      */
-    def get[S] = State[S, S] { state => (state, state) }
+    // Compose custom traversal with parent's generic traversal.
+    override def rewriteC(cmd: Command)(implicit env: Env) =
+      (myRewriteC.orElse(partialRewriteC))(cmd, env)
+    override def rewriteE(expr: Expr)(implicit env: Env) =
+      (myRewriteE.orElse(partialRewriteE))(expr, env)
   }
 
 }

--- a/src/main/scala/typechecker/AffineCheck.scala
+++ b/src/main/scala/typechecker/AffineCheck.scala
@@ -289,6 +289,9 @@ object AffineChecker {
           }
         }
       }
+      case (_: EPhysAccess, _) => {
+        throw NotImplemented("Affine checking for physical accesses.")
+      }
     }
   }
 }

--- a/src/main/scala/typechecker/CapabilityChecker.scala
+++ b/src/main/scala/typechecker/CapabilityChecker.scala
@@ -6,6 +6,7 @@ import fuselang.common._
 import Syntax._
 import Syntax.Annotations._
 import Errors._
+import CompilerError._
 import CapabilityEnv._
 import Checker._
 
@@ -33,6 +34,9 @@ object CapabilityChecker {
         }
         acc.consumable = Some(consumableAnn)
         nEnv.add(acc, cap)
+      }
+      case (_: EPhysAccess, _) => {
+        throw NotImplemented("Capability checking for physical accesses.")
       }
     }
 

--- a/src/main/scala/typechecker/TypeCheck.scala
+++ b/src/main/scala/typechecker/TypeCheck.scala
@@ -209,7 +209,7 @@ object TypeChecker {
           typ -> env
         }
       }
-    case EPhsAccess(id, bankIdxs) =>
+    case EPhysAccess(id, bankIdxs) =>
       env(id).matchOrError(expr.pos, "array access", s"array type") {
         case TArray(typ, dims, _) => {
           if (dims.length != bankIdxs.length) {


### PR DESCRIPTION
PR does a combination of things.

- Defines a new EPhysAccess AST node for representing physical accesses on
  array which are *only* meant for internal compiler code generator
  purposes. One day, we can expose these through user-facing syntax.
  - No user facing syntax for generating these accesses.
  - Stubbed out affine and capability checking.
- Rewrite `RewriteViews` pass using the `Transformer` interface.
