### PR TITLE
Vivado Customizable Mem Interfaces

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -16,6 +16,11 @@ object Main {
     "futil" -> Futil
   )
 
+  val memoryInterfaces = Map(
+    "ap_memory" -> ApMemory,
+    "axi" -> Axi
+  )
+
   val parser = new scopt.OptionParser[Config]("fuse") {
 
     head("fuse", "0.0.1")
@@ -66,6 +71,17 @@ object Main {
     opt[Unit]("pass-debug")
       .action((_, c) => c.copy(passDebug = true))
       .text("Show the AST after every compiler pass. Default: false.")
+
+    opt[String]("memory-interface")
+      .validate(b =>
+        if (memoryInterfaces.contains(b)) success
+        else
+          failure(
+            s"Invalid memory interface. Valid memory interfaces are ${memoryInterfaces.keys.mkString(", ")}"
+          )
+      )
+      .action((m, c) => c.copy(memoryInterface = memoryInterfaces(m)))
+      .text("The memory interface to use for the Vivado backend. Default `axi`")
 
     cmd("run")
       .action((_, c) => c.copy(mode = Run, backend = Cpp))

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -97,17 +97,10 @@ private class VivadoBackend extends CppLike {
       val argPragmas = func.args.map(arg =>
         arg.typ match {
           case _: TArray => {
-            text(
-              s"#pragma HLS INTERFACE m_axi port=${arg.id} offset=slave bundle=gmem"
-            ) <@>
-              text(
-                s"#pragma HLS INTERFACE s_axilite port=${arg.id} bundle=control"
-              )
+            text(s"#pragma HLS INTERFACE ap_none port=${arg.id}")
           }
           case _ =>
-            text(
-              s"#pragma HLS INTERFACE s_axilite port=${arg.id} bundle=control"
-            )
+            text(s"#pragma HLS INTERFACE ap_none port=${arg.id}")
         }
       )
 

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -97,10 +97,10 @@ private class VivadoBackend extends CppLike {
       val argPragmas = func.args.map(arg =>
         arg.typ match {
           case _: TArray => {
-            text(s"#pragma HLS INTERFACE ap_none port=${arg.id}")
+            text(s"#pragma HLS INTERFACE ap_memory port=${arg.id}")
           }
           case _ =>
-            text(s"#pragma HLS INTERFACE ap_none port=${arg.id}")
+            text(s"#pragma HLS INTERFACE ap_memory port=${arg.id}")
         }
       )
 

--- a/src/main/scala/backends/futil/FutilAst.scala
+++ b/src/main/scala/backends/futil/FutilAst.scala
@@ -243,6 +243,9 @@ object Stdlib {
   def mem_d1(width: Int, size: Int, idxSize: Int): Futil.CompInst =
     Futil.CompInst("std_mem_d1", List(width, size, idxSize))
 
+  def mem_d1_ext(width: Int, size: Int, idxSize: Int): Futil.CompInst =
+    Futil.CompInst("std_mem_d1_ext", List(width, size, idxSize))
+
   def mem_d2(
       width: Int,
       size0: Int,
@@ -251,6 +254,15 @@ object Stdlib {
       idxSize1: Int
   ): Futil.CompInst =
     Futil.CompInst("std_mem_d2", List(width, size0, size1, idxSize0, idxSize1))
+
+  def mem_d2_ext(
+      width: Int,
+      size0: Int,
+      size1: Int,
+      idxSize0: Int,
+      idxSize1: Int
+  ): Futil.CompInst =
+    Futil.CompInst("std_mem_d2_ext", List(width, size0, size1, idxSize0, idxSize1))
 
   def mem_d3(
       width: Int,
@@ -263,6 +275,20 @@ object Stdlib {
   ): Futil.CompInst =
     Futil.CompInst(
       "std_mem_d3",
+      List(width, size0, size1, size2, idxSize0, idxSize1, idxSize2)
+    )
+
+  def mem_d3_ext(
+      width: Int,
+      size0: Int,
+      size1: Int,
+      size2: Int,
+      idxSize0: Int,
+      idxSize1: Int,
+      idxSize2: Int
+  ): Futil.CompInst =
+    Futil.CompInst(
+      "std_mem_d3_ext",
       List(width, size0, size1, size2, idxSize0, idxSize1, idxSize2)
     )
 

--- a/src/main/scala/backends/futil/FutilBackend.scala
+++ b/src/main/scala/backends/futil/FutilBackend.scala
@@ -51,6 +51,10 @@ private class FutilBackendHelper {
     */
   type Store = Map[CompVar, CompVar]
 
+  /** `external` is a flag that differentiates between generating
+    *  external memories and internal memories. This is so that
+    *  we can generate external memories for `decl`s and internal
+    *  memories for local arrays. */
   def emitArrayDecl(typ: TArray, id: Id, external: Boolean): List[Structure] = {
     // No support for multi-ported memories or banked memories.
     assertOrThrow(

--- a/src/main/scala/backends/futil/FutilBackend.scala
+++ b/src/main/scala/backends/futil/FutilBackend.scala
@@ -51,7 +51,7 @@ private class FutilBackendHelper {
     */
   type Store = Map[CompVar, CompVar]
 
-  def emitArrayDecl(typ: TArray, id: Id): List[Structure] = {
+  def emitArrayDecl(typ: TArray, id: Id, external: Boolean): List[Structure] = {
     // No support for multi-ported memories or banked memories.
     assertOrThrow(
       typ.ports == 1,
@@ -76,14 +76,25 @@ private class FutilBackendHelper {
       case 1 => {
         val size = typ.dims(0)._1
         val idxSize = bitsNeeded(size)
-        LibDecl(name, Stdlib.mem_d1(width, size, idxSize))
+        if (external) {
+          LibDecl(name, Stdlib.mem_d1_ext(width, size, idxSize))
+        } else {
+          LibDecl(name, Stdlib.mem_d1(width, size, idxSize))
+        }
       }
       case 2 => {
         val size0 = typ.dims(0)._1
         val size1 = typ.dims(1)._1
         val idxSize0 = bitsNeeded(size0)
         val idxSize1 = bitsNeeded(size1)
-        LibDecl(name, Stdlib.mem_d2(width, size0, size1, idxSize0, idxSize1))
+        if (external) {
+          LibDecl(
+            name,
+            Stdlib.mem_d2_ext(width, size0, size1, idxSize0, idxSize1)
+          )
+        } else {
+          LibDecl(name, Stdlib.mem_d2(width, size0, size1, idxSize0, idxSize1))
+        }
       }
       case 3 => {
         val size0 = typ.dims(0)._1
@@ -92,11 +103,27 @@ private class FutilBackendHelper {
         val idxSize0 = bitsNeeded(size0)
         val idxSize1 = bitsNeeded(size1)
         val idxSize2 = bitsNeeded(size2)
-        LibDecl(
-          name,
-          Stdlib
-            .mem_d3(width, size0, size1, size2, idxSize0, idxSize1, idxSize2)
-        )
+        if (external) {
+          LibDecl(
+            name,
+            Stdlib
+              .mem_d3_ext(
+                width,
+                size0,
+                size1,
+                size2,
+                idxSize0,
+                idxSize1,
+                idxSize2
+              )
+          )
+        } else {
+          LibDecl(
+            name,
+            Stdlib
+              .mem_d3(width, size0, size1, size2, idxSize0, idxSize1, idxSize2)
+          )
+        }
       }
       case n => throw NotImplemented(s"Arrays of size $n")
     }
@@ -107,7 +134,7 @@ private class FutilBackendHelper {
     *  represent the declaration `d`. Simply returns a `List[Structure]`.
     */
   def emitDecl(d: Decl): List[Structure] = d.typ match {
-    case tarr: TArray => emitArrayDecl(tarr, d.id)
+    case tarr: TArray => emitArrayDecl(tarr, d.id, true)
     case _: TBool => {
       val reg = LibDecl(CompVar(s"${d.id}"), Stdlib.register(1))
       List(reg)
@@ -193,7 +220,9 @@ private class FutilBackendHelper {
       }
       case EVar(id) =>
         val portName = if (lhs) "in" else "out"
-        val varName = store.get(CompVar(s"$id")).getOrThrow(Impossible(s"$id was not in `store`"))
+        val varName = store
+          .get(CompVar(s"$id"))
+          .getOrThrow(Impossible(s"$id was not in `store`"))
         val struct =
           if (lhs) List(Connect(ConstantPort(1, 1), varName.port("write_en")))
           else List()
@@ -250,7 +279,7 @@ private class FutilBackendHelper {
         (struct1 ++ struct2, con1.seq(con2), s2)
       }
       case CLet(id, Some(tarr: TArray), None) =>
-        (emitArrayDecl(tarr, id), Empty, store)
+        (emitArrayDecl(tarr, id, false), Empty, store)
       case CLet(_, Some(_: TArray), Some(_)) =>
         throw NotImplemented(s"Futil backend cannot initialize memories", c.pos)
       case CLet(id, typ, Some(e)) => {

--- a/src/main/scala/common/Configuration.scala
+++ b/src/main/scala/common/Configuration.scala
@@ -14,6 +14,11 @@ object Configuration {
   final case object Cpp extends BackendOption
   final case object Futil extends BackendOption
 
+  // The type of Vivado memory interface to generate
+  sealed trait MemoryInterface
+  final case object ApMemory extends MemoryInterface
+  final case object Axi extends MemoryInterface
+
   val emptyConf = Config(null)
 
   case class Config(
@@ -26,7 +31,8 @@ object Configuration {
       header: Boolean = false, // Generate a header
       passDebug: Boolean = false, // Show AST after every state
       logLevel: scribe.Level = scribe.Level.Info,
-      enableLowering: Boolean = false // Enable lowering passes
+      enableLowering: Boolean = false, // Enable lowering passes
+      memoryInterface: MemoryInterface = Axi, // The memory interface to use for vivado
   )
 
 }


### PR DESCRIPTION
 - Add a `--memory-interface` flag to customize the memory interfaces that Dahlia generates for Vivado.
 - Change the Futil backend to emit external memories for `decls`