### PR TITLE
Allow for custom component name when lowering to FuTIL.

### DIFF
--- a/src/main/scala/backends/futil/FutilBackend.scala
+++ b/src/main/scala/backends/futil/FutilBackend.scala
@@ -651,7 +651,7 @@ private class FutilBackendHelper {
       "prog",
       List(
         Import("primitives/std.lib"),
-        Component(c.KernelName, List(), List(), struct.sorted, control)
+        Component(c.kernelName, List(), List(), struct.sorted, control)
       )
     ).emit
   }

--- a/src/main/scala/backends/futil/FutilBackend.scala
+++ b/src/main/scala/backends/futil/FutilBackend.scala
@@ -651,7 +651,7 @@ private class FutilBackendHelper {
       "prog",
       List(
         Import("primitives/std.lib"),
-        Component("main", List(), List(), struct.sorted, control)
+        Component(c.KernelName, List(), List(), struct.sorted, control)
       )
     ).emit
   }

--- a/src/main/scala/backends/futil/FutilBackend.scala
+++ b/src/main/scala/backends/futil/FutilBackend.scala
@@ -651,7 +651,7 @@ private class FutilBackendHelper {
       "prog",
       List(
         Import("primitives/std.lib"),
-        Component(c.kernelName, List(), List(), struct.sorted, control)
+        Component(if (c.kernelName == "kernel") "main" else c.kernelName, List(), List(), struct.sorted, control)
       )
     ).emit
   }


### PR DESCRIPTION
This passes in the kernel name of the configuration instead of a default string `"main"`.
So, when 
```
 ./fuse ./../futil/examples/dahlia/vectorized-add.fuse -n NewName -b futil --lower
```
is called, it produces: 
```
...
component NewName() -> () { ... }
``` 

However, it also means that the default would be "kernel" rather than "main," so what should we do here?