### PR TITLE
Add D4 memory to FuTIL backend.

### DIFF
--- a/src/main/scala/backends/futil/FutilAst.scala
+++ b/src/main/scala/backends/futil/FutilAst.scala
@@ -316,6 +316,38 @@ object Stdlib {
       List(width, size0, size1, size2, idxSize0, idxSize1, idxSize2)
     )
 
+    def mem_d4(
+        width: Int,
+        size0: Int,
+        size1: Int,
+        size2: Int,
+        size3: Int,
+        idxSize0: Int,
+        idxSize1: Int,
+        idxSize2: Int,
+        idxSize3: Int
+    ): Futil.CompInst =
+      Futil.CompInst(
+        "std_mem_d4",
+        List(width, size0, size1, size2, size3, idxSize0, idxSize1, idxSize2, idxSize3)
+      )
+
+    def mem_d4_ext(
+        width: Int,
+        size0: Int,
+        size1: Int,
+        size2: Int,
+        size3: Int,
+        idxSize0: Int,
+        idxSize1: Int,
+        idxSize2: Int,
+        idxSize3: Int
+    ): Futil.CompInst =
+      Futil.CompInst(
+        "std_mem_d4_ext",
+        List(width, size0, size1, size2, size3, idxSize0, idxSize1, idxSize2, idxSize3)
+      )
+
   def sqrt(): Futil.CompInst =
     Futil.CompInst("std_sqrt", List())
   

--- a/src/main/scala/backends/futil/FutilBackend.scala
+++ b/src/main/scala/backends/futil/FutilBackend.scala
@@ -143,6 +143,39 @@ private class FutilBackendHelper {
           )
         }
       }
+      case 4 => {
+              val size0 = typ.dims(0)._1
+              val size1 = typ.dims(1)._1
+              val size2 = typ.dims(2)._1
+              val size3 = typ.dims(3)._1
+              val idxSize0 = bitsNeeded(size0)
+              val idxSize1 = bitsNeeded(size1)
+              val idxSize2 = bitsNeeded(size2)
+              val idxSize3 = bitsNeeded(size3)
+              if (external) {
+                LibDecl(
+                  name,
+                  Stdlib
+                    .mem_d4_ext(
+                      width,
+                      size0,
+                      size1,
+                      size2,
+                      size3,
+                      idxSize0,
+                      idxSize1,
+                      idxSize2,
+                      idxSize3
+                    )
+                )
+              } else {
+                LibDecl(
+                  name,
+                  Stdlib
+                    .mem_d4(width, size0, size1, size2, size3, idxSize0, idxSize1, idxSize2, idxSize3)
+                )
+              }
+            }
       case n => throw NotImplemented(s"Arrays of size $n")
     }
     List(mem)


### PR DESCRIPTION
This is the simplest way to currently add another dimension to FuTIL backend with the given setup. This will suffice for the VGG Net example, but as discussed, next steps are using row major lookup for scalability purposes.

I've confirm this lowers (with the FuTIL additions to the primitive library):
```
decl A: ubit<32>[8][8][8][8];
```
->
```
import "primitives/std.lib";
component main() -> () {
  cells {
    A0_0_0_0 = prim std_mem_d4_ext(32,8,8,8,8,4,4,4,4);
  }
  wires {
  }
  control {
    empty
  }
}
```