### PR TITLE
Implement backend-specific imports

### DIFF
--- a/src/main/scala/backends/CppLike.scala
+++ b/src/main/scala/backends/CppLike.scala
@@ -174,8 +174,8 @@ object Cpp {
         } <+> name <> semi
     }
 
-    def emitInclude(incl: Include): Doc =
-      text("#include") <+> quote(text(incl.name))
+    def emitInclude(incl: String): Doc =
+      text("#include") <+> quote(text(incl))
 
   }
 

--- a/src/main/scala/backends/CppRunnable.scala
+++ b/src/main/scala/backends/CppRunnable.scala
@@ -8,6 +8,7 @@ import Configuration._
 import CompilerError._
 import PrettyPrint.Doc
 import PrettyPrint.Doc._
+import fuselang.common.{Configuration => C}
 
 /**
   * Same as [[fuselang.backend.VivadoBackend]] except this creates a main
@@ -178,7 +179,7 @@ private class CppRunnable extends CppLike {
     )
 
     // Add parsing library to the list of includes.
-    val includes = Include("parser.cpp", List()) +: p.includes
+    val includes = "parser.cpp" +: p.includes.flatMap(_.backends.get(C.Cpp))
 
     // Generate parsing helpers for all record defintions.
     val parseHelpers =
@@ -229,7 +230,8 @@ private class CppRunnableHeader extends CppRunnable {
   }
 
   override def emitProg(p: Prog, c: Config) = {
-    val includes = Include("parser.cpp", List()) +: p.includes
+    val includes: Seq[String] =
+      p.includes.flatMap(_.backends.get(C.Cpp)) :+ "parser.cpp"
 
     val declarations =
       vsep(includes.map(emitInclude)) <@>

--- a/src/main/scala/backends/VivadoBackend.scala
+++ b/src/main/scala/backends/VivadoBackend.scala
@@ -8,6 +8,7 @@ import Configuration._
 import CompilerError._
 import PrettyPrint.Doc
 import PrettyPrint.Doc._
+import fuselang.common.{Configuration => C}
 
 private class VivadoBackend(config: Config) extends CppLike {
   val CppPreamble: Doc = text("""
@@ -162,7 +163,7 @@ private class VivadoBackend(config: Config) extends CppLike {
   def emitProg(p: Prog, c: Config): String = {
     val layout =
       CppPreamble <@>
-        vsep(p.includes.map(emitInclude)) <@>
+        vsep(p.includes.flatMap(_.backends.get(C.Vivado).map(emitInclude))) <@>
         vsep(p.defs.map(emitDef)) <@>
         vsep(p.decors.map(d => text(d.value))) <@>
         emitFunc(FuncDef(Id(c.kernelName), p.decls, TVoid(), Some(p.cmd)), true)
@@ -183,7 +184,8 @@ private class VivadoBackendHeader(c: Config) extends VivadoBackend(c) {
 
   override def emitProg(p: Prog, c: Config) = {
     val declarations =
-      vsep(p.includes.map(emitInclude) ++ p.defs.map(emitDef)) <@>
+      vsep(p.includes.flatMap(_.backends.get(C.Vivado).map(emitInclude))) <@>
+      vsep(p.defs.map(emitDef)) <@>
         emitFunc(FuncDef(Id(c.kernelName), p.decls, TVoid(), None))
 
     declarations.pretty

--- a/src/main/scala/common/Configuration.scala
+++ b/src/main/scala/common/Configuration.scala
@@ -8,8 +8,21 @@ object Configuration {
   final case object Compile extends Mode
   final case object Run extends Mode
 
+  def stringToBackend(name: String): Option[BackendOption] = name match {
+    case "vivado" => Some(Vivado)
+    case "c++" => Some(Cpp)
+    case "futil" => Some(Futil)
+    case _ => None
+  }
+
   // What kind of code to generate.
-  sealed trait BackendOption
+  sealed trait BackendOption {
+    override def toString() = this match {
+      case Vivado => "vivado"
+      case Cpp => "c++"
+      case Futil => "futil"
+    }
+  }
   final case object Vivado extends BackendOption
   final case object Cpp extends BackendOption
   final case object Futil extends BackendOption

--- a/src/main/scala/common/Pretty.scala
+++ b/src/main/scala/common/Pretty.scala
@@ -19,7 +19,10 @@ object Pretty {
   }
 
   def emitInclude(incl: Include)(implicit debug: Boolean): Doc = {
-    text("import") <+> quote(text(incl.name)) <+> scope(
+    text("import") <+>
+    vsep(incl.backends.map({
+      case (b, incl) => text(b.toString) <> parens(quote(text(incl)))
+    })) <+> scope(
       vsep(incl.defs.map(emitDef))
     )
   }

--- a/src/main/scala/common/Syntax.scala
+++ b/src/main/scala/common/Syntax.scala
@@ -3,6 +3,7 @@ package fuselang.common
 import scala.util.parsing.input.{Positional, Position}
 
 import Errors._
+import Configuration.BackendOption
 
 object Syntax {
 
@@ -272,7 +273,10 @@ object Syntax {
   /**
     * An include with the name of the module and function definitions.
     */
-  case class Include(name: String, defs: Seq[FuncDef]) extends Positional
+  case class Include(
+    backends: Map[BackendOption, String],
+    defs: Seq[FuncDef]
+  ) extends Positional
 
   case class Decl(id: Id, typ: Type) extends Positional
   case class Prog(

--- a/src/test/scala/ParsingPositive.scala
+++ b/src/test/scala/ParsingPositive.scala
@@ -171,10 +171,10 @@ class ParsingTests extends org.scalatest.FunSuite {
 
   test("imports") {
     parseAst("""
-      import "print.h" {}
+      import vivado("print.h") {}
       """)
     parseAst("""
-      import "print.h" {
+      import c++("print.h") {
         def foo(a: bit<32>);
       }
       """)

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -1731,7 +1731,7 @@ class TypeCheckerSpec extends FunSpec {
   describe("Imports") {
     it("adds imported functions into type checking scope") {
       typeCheck("""
-        import "print.cpp" {
+        import vivado("print.cpp") {
           def print_vect(f: float[4]);
         }
         decl a: float[4];


### PR DESCRIPTION
Adds the following syntax for backend imports:
```
import c++("math.h") 
  vivado("vivado_math.h")
  futil("sqrt.futil") {
  def sqrt(in: ubit<32>): ubit<32>;
}
```