### PR TITLE
Fix `CLet` match ordering.

### DIFF
--- a/file-tests/should-futil/invoke-with-fixed-point.expect
+++ b/file-tests/should-futil/invoke-with-fixed-point.expect
@@ -1,0 +1,48 @@
+import "primitives/std.lib";
+component foo(x: 8) -> (out: 8) {
+  cells {
+    slice1 = std_slice(8,8);
+    y_0 = std_reg(8);
+  }
+  wires {
+    group let2<"static"=1> {
+      y_0.in = slice1.out;
+      y_0.write_en = 1'd1;
+      let2[done] = y_0.done;
+      slice1.in = x;
+    }
+    out = y_0.out;
+  }
+  control {
+    let2;
+  }
+}
+component main() -> () {
+  cells {
+    foo0 = foo();
+    fpconst0 = fixed_p_std_const(8,4,4,1,0);
+    slice0 = std_slice(8,8);
+    tmp_0 = std_reg(8);
+    x_0 = std_reg(8);
+  }
+  wires {
+    group let0<"static"=1> {
+      x_0.in = slice0.out;
+      x_0.write_en = 1'd1;
+      let0[done] = x_0.done;
+      slice0.in = fpconst0.out;
+    }
+    group let1 {
+      tmp_0.in = foo0.out;
+      tmp_0.write_en = 1'd1;
+      let1[done] = tmp_0.done;
+    }
+  }
+  control {
+    seq {
+      let0;
+      invoke foo0(x=x_0.out)();
+      let1;
+    }
+  }
+}

--- a/file-tests/should-futil/invoke-with-fixed-point.fuse
+++ b/file-tests/should-futil/invoke-with-fixed-point.fuse
@@ -1,0 +1,7 @@
+def foo(x: ufix<8, 4>): ufix<8, 4> = {
+  let y: ufix<8, 4> = x;
+  return y;
+}
+
+let x: ufix<8, 4> = (1.0 as ufix<8, 4>);
+let tmp: ufix<8, 4> = foo(x);


### PR DESCRIPTION
Originally, an earlier case `CLet(id, Some(TFixed(t, i, un)), Some(e)) => {` was being matched before the more specific criteria where `e == EApp`.

Fixes #353.