### PR TITLE
Hoisting Fixes

### DIFF
--- a/file-tests/should-lower/hoist.expect
+++ b/file-tests/should-lower/hoist.expect
@@ -1,0 +1,51 @@
+#include "parser.cpp"
+/***************** Parse helpers  ******************/
+/***************************************************/
+void kernel(vector<int> &a0, vector<int> &b0) {
+  
+  int b_read0_;
+  b_read0_ = b0[(unsigned int)0];
+  //---
+  int x_;
+  x_ = a0[(unsigned int)b_read0_];
+  //---
+  int a_read0_;
+  a_read0_ = a0[(unsigned int)0];
+  //---
+  int y_ = ((int)10 + a_read0_);
+  //---
+  int bin_read0_ = (x_ * (int)10);
+  //---
+  int bin_read1_ = (y_ * (int)20);
+  //---
+  int bin_read2_ = (bin_read0_ / (bin_read1_ - (int)15));
+  //---
+  int z_ = bin_read2_;
+  int w_;
+  int bin_read3_ = ((int)10 * (int)12);
+  //---
+  w_ = b0[(unsigned int)bin_read3_];
+  int bin_read4_ = (((int)0 - (int)1) * (int)1);
+  //---
+  int bin_read5_ = ((int)2 * (int)2);
+  //---
+  int bin_read6_ = (bin_read5_ * (int)2);
+  //---
+  int bin_read7_ = ((int)1 * (int)1);
+  //---
+  int bin_read8_ = ((int)1 * (int)2);
+  //---
+  unsigned int k_ = (unsigned int)(((bin_read4_ + bin_read6_) - bin_read7_) - bin_read8_);
+  json_t __;
+  __["a0"] = a0;
+  __["b0"] = b0;
+  std::cout << __.dump(2) << std::endl;
+}
+int main(int argc, char** argv) {
+  using namespace flattening;
+  auto v = parse_data(argc, argv);;
+  auto a0 = get_arg<n_dim_vec_t<int, 1>>("a0", "bit<32>[]", v);
+  auto b0 = get_arg<n_dim_vec_t<int, 1>>("b0", "bit<32>[]", v);
+  kernel(a0, b0);
+  return 0;
+}

--- a/file-tests/should-lower/hoist.fuse
+++ b/file-tests/should-lower/hoist.fuse
@@ -1,0 +1,18 @@
+decl a: bit<32>[1];
+decl b: bit<32>[1];
+
+// Recusively hoist nested reads
+let x = a[b[0]];
+---
+
+// Hoist binary expressions with reads
+let y = 10 + a[0];
+
+// Recusively hoist slow ops
+let z = (x * 10) / (y * 20 - 15);
+
+// Recursively hoist slow index expressions
+let w = b[10 * 12];
+
+// Complex chained binary expression
+let k = (((0-1) * 1 + (2*2) * 2 - 1*1 - 1*2) as ubit<32>);

--- a/src/main/scala/passes/HoistMemoryReads.scala
+++ b/src/main/scala/passes/HoistMemoryReads.scala
@@ -1,6 +1,7 @@
 package fuselang.passes
 
 import scala.{PartialFunction => PF}
+import scala.collection.immutable.ListMap
 import fuselang.common._
 import Transformer._
 import EnvHelpers._
@@ -9,7 +10,7 @@ import Syntax._
 object HoistMemoryReads extends PartialTransformer {
 
   // Env for storing the assignments for reads to replace
-  case class BufferEnv(map: Map[Expr, CLet])
+  case class BufferEnv(map: ListMap[Expr, CLet] = ListMap())
       extends ScopeManager[BufferEnv]
       with Tracker[Expr, CLet, BufferEnv] {
     def merge(that: BufferEnv) = {
@@ -24,7 +25,7 @@ object HoistMemoryReads extends PartialTransformer {
   }
 
   type Env = BufferEnv
-  val emptyEnv = BufferEnv(Map())
+  val emptyEnv = BufferEnv()
 
   /** Helper for generating unique names. */
   var idx: Map[String, Int] = Map();

--- a/src/main/scala/passes/HoistSlowBinop.scala
+++ b/src/main/scala/passes/HoistSlowBinop.scala
@@ -1,6 +1,7 @@
 package fuselang.passes
 
 import scala.{PartialFunction => PF}
+import scala.collection.immutable.ListMap
 import fuselang.common._
 import Syntax._
 import CompilerError._
@@ -9,7 +10,7 @@ import EnvHelpers._
 
 object HoistSlowBinop extends TypedPartialTransformer {
 
-  case class ExprEnv(map: Map[Expr, CLet])
+  case class ExprEnv(map: ListMap[Expr, CLet])
       extends ScopeManager[ExprEnv]
       with Tracker[Expr, CLet, ExprEnv] {
     def merge(that: ExprEnv) = {
@@ -22,7 +23,7 @@ object HoistSlowBinop extends TypedPartialTransformer {
   }
 
   type Env = ExprEnv
-  val emptyEnv = ExprEnv(Map())
+  val emptyEnv = ExprEnv(ListMap())
 
   private val slowBinops = List("*", "/")
 


### PR DESCRIPTION
Bunch of fixes for hoisting and a new test. Use `ListMap` instead of `Map` because `Map` does not generate statement in order of hoisting.

- recursively hoist index expressions
- use ListMap instead of Map to preserve insertion order
- add test for hoisting

Fixed #360.
