### PR TITLE
Fix timing bug with multi-cycle.

### DIFF
--- a/file-tests/should-futil/fixed-point-multi-cycle.expect
+++ b/file-tests/should-futil/fixed-point-multi-cycle.expect
@@ -13,7 +13,7 @@ component main() -> () {
     mult_pipe1 = std_smult_pipe(1);
   }
   wires {
-    group let0<"static"=3> {
+    group let0<"static"=4> {
       bin_read0_0.in = mult_pipe0.out;
       bin_read0_0.write_en = mult_pipe0.done;
       let0[done] = bin_read0_0.done;

--- a/file-tests/should-futil/fixed-point-multi-cycle.expect
+++ b/file-tests/should-futil/fixed-point-multi-cycle.expect
@@ -3,14 +3,15 @@ component main() -> () {
   cells {
     b_0 = std_reg(2);
     bin_read0_0 = std_reg(2);
-    bin_read1_0 = std_reg(1);
-    const0 = std_const(1,1);
-    const1 = std_const(1,1);
-    d_0 = std_reg(1);
+    bin_read1_0 = std_reg(2);
+    const0 = std_const(1,0);
+    d0 = std_mem_d1(2,1,1);
     fp_const0 = std_const(2,2);
     fp_const1 = std_const(2,2);
+    fp_const2 = std_const(2,2);
+    fp_const3 = std_const(2,2);
     mult_pipe0 = std_fp_mult_pipe(2,1,1);
-    mult_pipe1 = std_smult_pipe(1);
+    mult_pipe1 = std_fp_mult_pipe(2,1,1);
   }
   wires {
     group let0<"static"=4> {
@@ -30,26 +31,23 @@ component main() -> () {
       bin_read1_0.in = mult_pipe1.out;
       bin_read1_0.write_en = mult_pipe1.done;
       let2[done] = bin_read1_0.done;
-      mult_pipe1.left = const0.out;
-      mult_pipe1.right = const1.out;
+      mult_pipe1.left = fp_const2.out;
+      mult_pipe1.right = fp_const3.out;
       mult_pipe1.go = !mult_pipe1.done ? 1'd1;
     }
-    group let3<"static"=1> {
-      d_0.in = bin_read1_0.out;
-      d_0.write_en = 1'd1;
-      let3[done] = d_0.done;
+    group upd0<"static"=1> {
+      d0.addr0 = const0.out;
+      d0.write_en = 1'd1;
+      d0.write_data = 1'd1 ? bin_read1_0.out;
+      upd0[done] = d0.done ? 1'd1;
     }
   }
   control {
-    par {
-      seq {
-        let0;
-        let1;
-      }
-      seq {
-        let2;
-        let3;
-      }
+    seq {
+      let0;
+      let1;
+      let2;
+      upd0;
     }
   }
 }

--- a/file-tests/should-futil/fixed-point-multi-cycle.fuse
+++ b/file-tests/should-futil/fixed-point-multi-cycle.fuse
@@ -1,2 +1,7 @@
 let b: ufix<2, 1> = (1.0 as ufix<2, 1>) * (1.0 as ufix<2, 1>);
-let d: bit<1> = (1 as bit<1>) * (1 as bit<1>);
+
+let d: ufix<2, 1>[1];
+---
+d[0] := (1.0 as ufix<2, 1>) * (1.0 as ufix<2, 1>);
+
+

--- a/src/main/scala/backends/futil/FutilBackend.scala
+++ b/src/main/scala/backends/futil/FutilBackend.scala
@@ -879,7 +879,7 @@ def emitInvokeDecl(app: EApp)(implicit store: Store, id2FuncDef: FunctionMapping
         // the multi-cycle operation is complete, if it exists.
         val (writeEnableSrcPort, delay) = out.multiCycleInfo match {
           case Some((compVar, Some(delay))) =>
-            (CompPort(compVar, "done"), out.delay.map(_ + delay))
+            (CompPort(compVar, "done"), out.delay.map(_ + delay + 1))
           case Some((compVar, None)) =>
             (CompPort(compVar, "done"), None)
           case None => (out.done, out.delay.map(_ + 1))


### PR DESCRIPTION
Writing to a register takes `1` cycle, and a `mult_pipe` takes 3 cycles for a total of 4 cycles. Thanks @rachitnigam for pointing out basic arithmetic to me.

Inadvertently fixes [Calyx 498](https://github.com/cucapra/calyx/issues/498).