### PR TITLE
Correctly rewrite function definitions

### DIFF
--- a/src/main/scala/common/Transformer.scala
+++ b/src/main/scala/common/Transformer.scala
@@ -67,7 +67,7 @@ object Transformer {
         val (nBody, env2) = bodyOpt match {
           case None => (None, env1)
           case Some(body) => {
-            val (nbody, nEnv) = rewriteC(body)(env1)
+            val (nbody, nEnv) = env1.withScopeAndRet(rewriteC(body)(_))
             Some(nbody) -> nEnv
           }
         }


### PR DESCRIPTION
The transformer method for rewriting the funcDefs was not using a new scope causing definitions to bleed into the parent context. This PR fixes that.

Fixes #372.
