### PR TITLE
Revert combinational group generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ compiled/
 *~
 .DS_Store
 .projectile
+.bsp

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ compiled/
 *~
 .DS_Store
 .projectile
-.bsp

--- a/file-tests/should-futil/for.expect
+++ b/file-tests/should-futil/for.expect
@@ -14,7 +14,8 @@ component main() -> () {
     le0 = std_le(4);
   }
   wires {
-    comb group cond0 {
+    group cond0<"static"=0> {
+      cond0[done] = 1'd1;
       le0.left = i0.out;
       le0.right = const1.out;
     }

--- a/src/main/scala/Utils.scala
+++ b/src/main/scala/Utils.scala
@@ -4,7 +4,7 @@ import scala.math.{log10, ceil, abs}
 
 object Utils {
 
-  implicit class RichOption[A](opt: => Option[A]) {
+  implicit class RichOption[A](opt: Option[A]) {
     def getOrThrow[T <: Throwable](except: T) = opt match {
       case Some(v) => v
       case None => throw except


### PR DESCRIPTION
Temporarily revert changes to generate `comb group` in the Calyx backend on master so that the tests in the Calyx repo don't fail.
