### PR TITLE
Emit `comb group` for Calyx backend

### DIFF
--- a/file-tests/should-futil/for.expect
+++ b/file-tests/should-futil/for.expect
@@ -14,8 +14,7 @@ component main() -> () {
     le0 = std_le(4);
   }
   wires {
-    group cond0<"static"=0> {
-      cond0[done] = 1'd1;
+    comb group cond0 {
       le0.left = i0.out;
       le0.right = const1.out;
     }

--- a/src/main/scala/Utils.scala
+++ b/src/main/scala/Utils.scala
@@ -4,7 +4,7 @@ import scala.math.{log10, ceil, abs}
 
 object Utils {
 
-  implicit class RichOption[A](opt: Option[A]) {
+  implicit class RichOption[A](opt: => Option[A]) {
     def getOrThrow[T <: Throwable](except: T) = opt match {
       case Some(v) => v
       case None => throw except

--- a/src/main/scala/backends/calyx/Ast.scala
+++ b/src/main/scala/backends/calyx/Ast.scala
@@ -2,6 +2,8 @@ package fuselang.backend.calyx
 
 import scala.math.BigInt
 import fuselang.common.PrettyPrint.Doc
+import fuselang.common.CompilerError._
+import fuselang.Utils.RichOption
 import Doc._
 
 object Calyx {
@@ -95,12 +97,22 @@ object Calyx {
       case (HolePort(thisId, _), HolePort(thatId, _)) => thisId.compare(thatId)
       case (ConstantPort(_, thisV), ConstantPort(_, thatV)) =>
         thisV.compare(thatV)
-      case (ThisPort(_), _) => 1
-      case (_, ThisPort(_)) => -1
-      case (CompPort(_, _), _) => 1
-      case (_, CompPort(_, _)) => -1
-      case (ConstantPort(_, _), _) => 1
-      case (_, ConstantPort(_, _)) => -1
+      case (_: ThisPort, _) => 1
+      case (_, _: ThisPort) => -1
+      case (_: CompPort, _) => 1
+      case (_, _: CompPort) => -1
+      case (_: ConstantPort, _) => 1
+      case (_, _: ConstantPort) => -1
+    }
+
+    def isHole(): Boolean = this match {
+      case _: HolePort => true
+      case _ => false
+    }
+
+    def isConstant(value: Int, width: Int) = this match {
+      case ConstantPort(v, w) if v == value && w == width => true
+      case _ => false
     }
   }
 
@@ -128,12 +140,12 @@ object Calyx {
         dest.doc() <+> equal <+> src.doc() <> semi
       case Assign(src, dest, guard) =>
         dest.doc() <+> equal <+> guard.doc() <+> text("?") <+> src.doc() <> semi
-      case Group(id, conns, Some(delay)) =>
-        text("group") <+> id.doc() <>
-          angles(text("\"static\"") <> equal <> text(delay.toString())) <+>
-          scope(vsep(conns.map(_.doc())))
-      case Group(id, conns, None) =>
-        text("group") <+> id.doc() <+>
+      case Group(id, conns, delay, comb) =>
+        (if (comb) text("comb ") else emptyDoc) <>
+          text("group") <+> id.doc() <>
+          (if (delay.isDefined)
+             angles(text("\"static\"") <> equal <> text(delay.get.toString()))
+           else emptyDoc) <+>
           scope(vsep(conns.map(_.doc())))
     }
 
@@ -141,7 +153,7 @@ object Calyx {
       (this, that) match {
         case (Cell(thisId, _, _), Cell(thatId, _, _)) =>
           thisId.compare(thatId)
-        case (Group(thisId, _, _), Group(thatId, _, _)) =>
+        case (Group(thisId, _, _, _), Group(thatId, _, _, _)) =>
           thisId.compare(thatId)
         case (Assign(thisSrc, thisDest, _), Assign(thatSrc, thatDest, _)) => {
           if (thisSrc.compare(thatSrc) == 0) {
@@ -150,10 +162,10 @@ object Calyx {
             thisSrc.compare(thatSrc)
           }
         }
-        case (Cell(_, _, _), _) => -1
-        case (_, Cell(_, _, _)) => 1
-        case (Group(_, _, _), _) => -1
-        case (_, Group(_, _, _)) => 1
+        case (_: Cell, _) => -1
+        case (_, _: Cell) => 1
+        case (_: Group, _) => -1
+        case (_, _: Group) => 1
       }
     }
   }
@@ -162,7 +174,9 @@ object Calyx {
   case class Group(
       id: CompVar,
       connections: List[Assign],
-      staticDelay: Option[Int]
+      staticDelay: Option[Int],
+      // True if the group is combinational
+      combinationa: Boolean
   ) extends Structure
   case class Assign(src: Port, dest: Port, guard: GuardExpr = True)
       extends Structure
@@ -179,7 +193,18 @@ object Calyx {
           case s => Right(s)
         }
       )
-      (this(id, connections, staticDelay), st)
+      val doneAssign = connections
+        .find(assign => assign.dest.isHole())
+        .getOrThrow(Impossible("Group does not have a done hole"))
+
+      // If this is a combinational group, remove the group done assignment
+      val isComb = doneAssign.guard == True && doneAssign.src.isConstant(1, 1)
+      val conns = if (isComb) {
+        connections.filter(assign => !assign.dest.isHole())
+      } else {
+        connections
+      }
+      (this(id, conns, if (isComb) None else staticDelay, isComb), st)
     }
   }
 


### PR DESCRIPTION
Bring back `comb group` generation in the Calyx backend.
