### PR TITLE
[Sequentialize] CReduce is both define and use.

### DIFF
--- a/file-tests/should-futil/sequentialize-reduce.expect
+++ b/file-tests/should-futil/sequentialize-reduce.expect
@@ -1,0 +1,85 @@
+import "primitives/core.futil";
+import "primitives/binary_operators.futil";
+component main() -> () {
+  cells {
+    add0 = std_add(4);
+    add1 = std_add(4);
+    add2 = std_add(4);
+    const0 = std_const(4,0);
+    const1 = std_const(4,9);
+    const2 = std_const(4,0);
+    const3 = std_const(4,0);
+    const4 = std_const(4,9);
+    const5 = std_const(4,1);
+    const6 = std_const(4,1);
+    i0 = std_reg(4);
+    j0 = std_reg(4);
+    le0 = std_le(4);
+    le1 = std_le(4);
+    x_0 = std_reg(4);
+  }
+  wires {
+    comb group cond0 {
+      le0.left = i0.out;
+      le0.right = const1.out;
+    }
+    comb group cond1 {
+      le1.left = j0.out;
+      le1.right = const4.out;
+    }
+    group let0<"static"=1> {
+      i0.in = const0.out;
+      i0.write_en = 1'd1;
+      let0[done] = i0.done;
+    }
+    group let1<"static"=1> {
+      x_0.in = const2.out;
+      x_0.write_en = 1'd1;
+      let1[done] = x_0.done;
+    }
+    group let2<"static"=1> {
+      j0.in = const3.out;
+      j0.write_en = 1'd1;
+      let2[done] = j0.done;
+    }
+    group upd0<"static"=1> {
+      x_0.write_en = 1'd1;
+      add0.left = x_0.out;
+      add0.right = j0.out;
+      x_0.in = 1'd1 ? add0.out;
+      upd0[done] = x_0.done ? 1'd1;
+    }
+    group upd1<"static"=1> {
+      j0.write_en = 1'd1;
+      add1.left = j0.out;
+      add1.right = const5.out;
+      j0.in = 1'd1 ? add1.out;
+      upd1[done] = j0.done ? 1'd1;
+    }
+    group upd2<"static"=1> {
+      i0.write_en = 1'd1;
+      add2.left = i0.out;
+      add2.right = const6.out;
+      i0.in = 1'd1 ? add2.out;
+      upd2[done] = i0.done ? 1'd1;
+    }
+  }
+  control {
+    seq {
+      let0;
+      @bound(10) while le0.out with cond0 {
+        seq {
+          let1;
+          let2;
+          @bound(10) while le1.out with cond1 {
+            seq {
+              upd0;
+              upd1;
+            }
+          }
+          upd2;
+        }
+      }
+    }
+  }
+}

--- a/file-tests/should-futil/sequentialize-reduce.fuse
+++ b/file-tests/should-futil/sequentialize-reduce.fuse
@@ -1,0 +1,6 @@
+for (let i: ubit<4> = 0..10) {
+  let x: ubit<4> = 0;
+  for (let j: ubit<4> = 0..10) {
+    x += j;
+  }
+}


### PR DESCRIPTION
Bug found by the Calyx interpreter. The problem was that expressions
like `x += 10` were only considered to be defines and not uses which
meant the sequentializer would try to run something like the following
in parallel.

```
x = 10;
x += 10;
```
