### PR TITLE
Generate `ref cell` for memory arguments

### DIFF
--- a/file-tests/should-futil/fixed-point-multi-cycle.expect
+++ b/file-tests/should-futil/fixed-point-multi-cycle.expect
@@ -39,8 +39,8 @@ component main() -> () {
     group upd0<"static"=1> {
       d0.addr0 = const0.out;
       d0.write_en = 1'd1;
-      d0.write_data = 1'd1 ? bin_read1_0.out;
-      upd0[done] = d0.done ? 1'd1;
+      d0.write_data = bin_read1_0.out;
+      upd0[done] = d0.done;
     }
   }
   control {

--- a/file-tests/should-futil/for.expect
+++ b/file-tests/should-futil/for.expect
@@ -27,23 +27,23 @@ component main() -> () {
     group upd0<"static"=1> {
       A_read0_0.write_en = 1'd1;
       A0.addr0 = i0.out;
-      A_read0_0.in = 1'd1 ? A0.read_data;
-      upd0[done] = A_read0_0.done ? 1'd1;
+      A_read0_0.in = A0.read_data;
+      upd0[done] = A_read0_0.done;
     }
     group upd1<"static"=1> {
       B0.addr0 = i0.out;
       B0.write_en = 1'd1;
       add0.left = A_read0_0.out;
       add0.right = const2.out;
-      B0.write_data = 1'd1 ? add0.out;
-      upd1[done] = B0.done ? 1'd1;
+      B0.write_data = add0.out;
+      upd1[done] = B0.done;
     }
     group upd2<"static"=1> {
       i0.write_en = 1'd1;
       add1.left = i0.out;
       add1.right = const3.out;
-      i0.in = 1'd1 ? add1.out;
-      upd2[done] = i0.done ? 1'd1;
+      i0.in = add1.out;
+      upd2[done] = i0.done;
     }
   }
   control {

--- a/file-tests/should-futil/invoke-with-fixed-point.expect
+++ b/file-tests/should-futil/invoke-with-fixed-point.expect
@@ -5,15 +5,15 @@ component foo(x: 8) -> (@stable(1) out: 8) {
     y_0 = std_reg(8);
   }
   wires {
-    group let2<"static"=1> {
+    group let0<"static"=1> {
       y_0.in = x;
       y_0.write_en = 1'd1;
-      let2[done] = y_0.done;
+      let0[done] = y_0.done;
     }
     out = y_0.out;
   }
   control {
-    let2;
+    let0;
   }
 }
 component main() -> () {
@@ -24,22 +24,22 @@ component main() -> () {
     x_0 = std_reg(8);
   }
   wires {
-    group let0<"static"=1> {
+    group let1<"static"=1> {
       x_0.in = fp_const0.out;
       x_0.write_en = 1'd1;
-      let0[done] = x_0.done;
+      let1[done] = x_0.done;
     }
-    group let1 {
+    group let2 {
       tmp_0.in = foo0.out;
       tmp_0.write_en = 1'd1;
-      let1[done] = tmp_0.done;
+      let2[done] = tmp_0.done;
     }
   }
   control {
     seq {
-      let0;
-      invoke foo0(x=x_0.out)();
       let1;
+      invoke foo0(x=x_0.out)();
+      let2;
     }
   }
 }

--- a/file-tests/should-futil/invoke-with-memories.expect
+++ b/file-tests/should-futil/invoke-with-memories.expect
@@ -1,7 +1,9 @@
 import "primitives/core.futil";
 import "primitives/binary_operators.futil";
-component mem_copy(dest0_read_data: 32, dest0_done: 1, src0_read_data: 32, src0_done: 1) -> (dest0_write_data: 32, dest0_write_en: 1, dest0_addr0: 1, src0_write_data: 32, src0_write_en: 1, src0_addr0: 1) {
+component mem_copy() -> () {
   cells {
+    ref dest0 = std_mem_d1(32,1,1);
+    ref src0 = std_mem_d1(32,1,1);
     const0 = std_const(1,0);
     src_read0_0 = std_reg(32);
     zero_0 = std_reg(1);
@@ -14,15 +16,15 @@ component mem_copy(dest0_read_data: 32, dest0_done: 1, src0_read_data: 32, src0_
     }
     group upd0<"static"=1> {
       src_read0_0.write_en = 1'd1;
-      src0_addr0 = zero_0.out;
-      src_read0_0.in = 1'd1 ? src0_read_data;
-      upd0[done] = src_read0_0.done ? 1'd1;
+      src0.addr0 = zero_0.out;
+      src_read0_0.in = src0.read_data;
+      upd0[done] = src_read0_0.done;
     }
     group upd1<"static"=1> {
-      dest0_addr0 = zero_0.out;
-      dest0_write_en = 1'd1;
-      dest0_write_data = 1'd1 ? src_read0_0.out;
-      upd1[done] = dest0_done ? 1'd1;
+      dest0.addr0 = zero_0.out;
+      dest0.write_en = 1'd1;
+      dest0.write_data = src_read0_0.out;
+      upd1[done] = dest0.done;
     }
   }
   control {
@@ -43,7 +45,7 @@ component main() -> () {
   }
   control {
     seq {
-      invoke mem_copy0(dest0_read_data=d0.read_data, dest0_done=d0.done, src0_read_data=s0.read_data, src0_done=s0.done)(dest0_write_data=d0.write_data, dest0_write_en=d0.write_en, dest0_addr0=d0.addr0, src0_write_data=s0.write_data, src0_write_en=s0.write_en, src0_addr0=s0.addr0);
+      invoke mem_copy0[dest0=d0, src0=s0]()();
     }
   }
 }

--- a/file-tests/should-futil/invoke.expect
+++ b/file-tests/should-futil/invoke.expect
@@ -6,15 +6,15 @@ component foo(a: 32) -> (@stable(1) out: 32) {
     temp_0 = std_reg(32);
   }
   wires {
-    group let3<"static"=1> {
+    group let0<"static"=1> {
       temp_0.in = a;
       temp_0.write_en = 1'd1;
-      let3[done] = temp_0.done;
+      let0[done] = temp_0.done;
     }
     out = temp_0.out;
   }
   control {
-    let3;
+    let0;
   }
 }
 component main() -> () {
@@ -27,29 +27,29 @@ component main() -> () {
     sqrt0 = sqrt(32);
   }
   wires {
-    group let0<"static"=1> {
+    group let1<"static"=1> {
       b_0.in = const0.out;
       b_0.write_en = 1'd1;
-      let0[done] = b_0.done;
-    }
-    group let1 {
-      c_0.in = foo0.out;
-      c_0.write_en = 1'd1;
-      let1[done] = c_0.done;
+      let1[done] = b_0.done;
     }
     group let2 {
+      c_0.in = foo0.out;
+      c_0.write_en = 1'd1;
+      let2[done] = c_0.done;
+    }
+    group let3 {
       d_0.in = sqrt0.out;
       d_0.write_en = 1'd1;
-      let2[done] = d_0.done;
+      let3[done] = d_0.done;
     }
   }
   control {
     seq {
-      let0;
-      invoke foo0(a=b_0.out)();
       let1;
-      invoke sqrt0(in=c_0.out)();
+      invoke foo0(a=b_0.out)();
       let2;
+      invoke sqrt0(in=c_0.out)();
+      let3;
     }
   }
 }

--- a/file-tests/should-futil/sequentialize-reduce.expect
+++ b/file-tests/should-futil/sequentialize-reduce.expect
@@ -46,22 +46,22 @@ component main() -> () {
       x_0.write_en = 1'd1;
       add0.left = x_0.out;
       add0.right = j0.out;
-      x_0.in = 1'd1 ? add0.out;
-      upd0[done] = x_0.done ? 1'd1;
+      x_0.in = add0.out;
+      upd0[done] = x_0.done;
     }
     group upd1<"static"=1> {
       j0.write_en = 1'd1;
       add1.left = j0.out;
       add1.right = const5.out;
-      j0.in = 1'd1 ? add1.out;
-      upd1[done] = j0.done ? 1'd1;
+      j0.in = add1.out;
+      upd1[done] = j0.done;
     }
     group upd2<"static"=1> {
       i0.write_en = 1'd1;
       add2.left = i0.out;
       add2.right = const6.out;
-      i0.in = 1'd1 ? add2.out;
-      upd2[done] = i0.done ? 1'd1;
+      i0.in = add2.out;
+      upd2[done] = i0.done;
     }
   }
   control {

--- a/runt.toml
+++ b/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.3.2"
+ver = "0.4.0"
 
 [[tests]]
 name = "compile vivado"

--- a/src/main/scala/backends/calyx/Ast.scala
+++ b/src/main/scala/backends/calyx/Ast.scala
@@ -285,7 +285,10 @@ object Calyx {
             cond.doc() <+>
             scope(body.doc())
         case Enable(id) => id.doc() <> semi
-        case Invoke(id, _, inConnects, outConnects) => {
+        case Invoke(id, refCells, inConnects, outConnects) => {
+          val cells = refCells.map({
+            case (param, cell) => text(param) <> equal <> cell.doc()
+          })
           val inputDefs = inConnects.map({
             case (param, arg) => text(param) <> equal <> arg.doc()
           })
@@ -293,6 +296,7 @@ object Calyx {
             case (param, arg) => text(param) <> equal <> arg.doc()
           })
           text("invoke") <+> id.doc() <>
+            brackets(commaSep(cells)) <>
             parens(commaSep(inputDefs)) <>
             parens(commaSep(outputDefs)) <> semi
         }

--- a/src/main/scala/backends/calyx/Ast.scala
+++ b/src/main/scala/backends/calyx/Ast.scala
@@ -286,9 +286,13 @@ object Calyx {
             scope(body.doc())
         case Enable(id) => id.doc() <> semi
         case Invoke(id, refCells, inConnects, outConnects) => {
-          val cells = refCells.map({
-            case (param, cell) => text(param) <> equal <> cell.doc()
-          })
+          val cells =
+            if (refCells.isEmpty)
+              emptyDoc
+            else
+              brackets(commaSep(refCells.map({
+                case (param, cell) => text(param) <> equal <> cell.doc()
+              })))
           val inputDefs = inConnects.map({
             case (param, arg) => text(param) <> equal <> arg.doc()
           })
@@ -296,7 +300,7 @@ object Calyx {
             case (param, arg) => text(param) <> equal <> arg.doc()
           })
           text("invoke") <+> id.doc() <>
-            brackets(commaSep(cells)) <>
+            cells <>
             parens(commaSep(inputDefs)) <>
             parens(commaSep(outputDefs)) <> semi
         }

--- a/src/main/scala/backends/calyx/Ast.scala
+++ b/src/main/scala/backends/calyx/Ast.scala
@@ -222,6 +222,12 @@ object Calyx {
     }
   }
   case class Atom(item: Port) extends GuardExpr
+  object Atom {
+    def apply(item: Port): GuardExpr = item match {
+      case ConstantPort(1, v) if v == 1 => True
+      case _ => new Atom(item)
+    }
+  }
   case class And(left: GuardExpr, right: GuardExpr) extends GuardExpr
   case class Or(left: GuardExpr, right: GuardExpr) extends GuardExpr
   case class Not(inner: GuardExpr) extends GuardExpr

--- a/src/main/scala/backends/calyx/Backend.scala
+++ b/src/main/scala/backends/calyx/Backend.scala
@@ -895,11 +895,11 @@ private class CalyxBackendHelper {
         val rOut = emitExpr(rhs)(store)
         val lOut = emitExpr(lhs, Some((rOut.done, rOut.delay)))(store)
         val groupName = genName("upd")
+        // The group is done when the left register commits the write.
         val doneHole =
           Assign(
-            ConstantPort(1, 1),
+            lOut.done,
             HolePort(groupName, "done"),
-            Atom(lOut.done)
           )
         val struct =
           lOut.structure ++ rOut.structure ++ List(


### PR DESCRIPTION
Builds upon @paili0628's work on adding the new `ref cell` syntax to Calyx. Instead of manually inlining interface ports of memories, generates memory cells with `ref` in them.
