### PR TITLE
always maps to seq-mems now

### DIFF
--- a/file-tests/should-futil/for-multi-dim.expect
+++ b/file-tests/should-futil/for-multi-dim.expect
@@ -1,0 +1,99 @@
+import "primitives/core.futil";
+import "primitives/memories.futil";
+import "primitives/binary_operators.futil";
+component main() -> () {
+  cells {
+    @external(1) A0_0 = seq_mem_d2(32,10,2,4,2);
+    A_read0_0 = std_reg(32);
+    @external(1) B0_0 = seq_mem_d2(32,10,2,4,2);
+    add0 = std_sadd(32);
+    add1 = std_add(2);
+    add2 = std_add(4);
+    const0 = std_const(4,0);
+    const1 = std_const(4,9);
+    const2 = std_const(2,0);
+    const3 = std_const(2,1);
+    const4 = std_const(32,1);
+    const5 = std_const(2,1);
+    const6 = std_const(4,1);
+    i0 = std_reg(4);
+    j0 = std_reg(2);
+    le0 = std_le(4);
+    le1 = std_le(2);
+  }
+  wires {
+    comb group cond0 {
+      le0.left = i0.out;
+      le0.right = const1.out;
+    }
+    comb group cond1 {
+      le1.left = j0.out;
+      le1.right = const3.out;
+    }
+    group let0<"static"=1> {
+      i0.in = const0.out;
+      i0.write_en = 1'd1;
+      let0[done] = i0.done;
+    }
+    group let1<"static"=1> {
+      j0.in = const2.out;
+      j0.write_en = 1'd1;
+      let1[done] = j0.done;
+    }
+    group upd0<"static"=2> {
+      A_read0_0.write_en = A0_0.read_done;
+      A0_0.addr1 = j0.out;
+      A0_0.addr0 = i0.out;
+      A0_0.read_en = 1'd1;
+      A_read0_0.in = A0_0.out;
+      upd0[done] = A_read0_0.done;
+    }
+    group upd1<"static"=1> {
+      B0_0.addr1 = j0.out;
+      B0_0.addr0 = i0.out;
+      B0_0.write_en = 1'd1;
+      add0.left = A_read0_0.out;
+      add0.right = const4.out;
+      B0_0.in = add0.out;
+      upd1[done] = B0_0.write_done;
+    }
+    group upd2<"static"=1> {
+      j0.write_en = 1'd1;
+      add1.left = j0.out;
+      add1.right = const5.out;
+      j0.in = add1.out;
+      upd2[done] = j0.done;
+    }
+    group upd3<"static"=1> {
+      i0.write_en = 1'd1;
+      add2.left = i0.out;
+      add2.right = const6.out;
+      i0.in = add2.out;
+      upd3[done] = i0.done;
+    }
+  }
+  control {
+    seq {
+      @pos(0) let0;
+      @bound(10) while le0.out with cond0 {
+        seq {
+          @pos(1) let1;
+          @bound(2) while le1.out with cond1 {
+            seq {
+              @pos(2) upd0;
+              @pos(3) upd1;
+              @pos(1) upd2;
+            }
+          }
+          @pos(0) upd3;
+        }
+      }
+    }
+  }
+}
+metadata #{
+  0: for (let i: ubit<4> = 0..10) {
+  1:   for (let j: ubit<2> = 0..2){
+  2:     B[i][j] := A[i][j] + 1;
+  3:     B[i][j] := A[i][j] + 1;
+}#

--- a/file-tests/should-futil/for-multi-dim.fuse
+++ b/file-tests/should-futil/for-multi-dim.fuse
@@ -1,0 +1,8 @@
+decl A: bit<32>[10][2];
+decl B: bit<32>[10][2];
+
+for (let i: ubit<4> = 0..10) {
+  for (let j: ubit<2> = 0..2){
+    B[i][j] := A[i][j] + 1;
+  }
+}


### PR DESCRIPTION
I realized that the open PR I have in Calyx will only work if Dahlia maps to 2d, 3d, and 4d sequential mems. So I made some quick fixes to do that. 

Once we get this merged, I can update my current Calyx PR and see what fails. 