### PR TITLE
Pass mutli-cycle info (needed to fix LeNet)

### DIFF
--- a/file-tests/should-futil/use-plus-equals.expect
+++ b/file-tests/should-futil/use-plus-equals.expect
@@ -1,0 +1,117 @@
+import "primitives/core.futil";
+import "primitives/memories.futil";
+import "primitives/binary_operators.futil";
+component use_plus_equals() -> () {
+  cells {
+    ref x20_0 = seq_mem_d2(32,1,2,1,2);
+    __i0 = std_reg(1);
+    __j0 = std_reg(2);
+    __x_0 = std_reg(32);
+    add0 = std_fp_sadd(32,16,16);
+    add1 = std_add(2);
+    add2 = std_add(1);
+    const0 = std_const(1,0);
+    const1 = std_const(1,0);
+    const2 = std_const(2,0);
+    const3 = std_const(2,1);
+    const4 = std_const(2,1);
+    const5 = std_const(1,1);
+    fp_const0 = std_const(32,131072);
+    le0 = std_le(1);
+    le1 = std_le(2);
+    red_read00 = std_reg(32);
+  }
+  wires {
+    comb group cond0 {
+      le0.left = __i0.out;
+      le0.right = const1.out;
+    }
+    comb group cond1 {
+      le1.left = __j0.out;
+      le1.right = const3.out;
+    }
+    group let0<"static"=1> {
+      __i0.in = const0.out;
+      __i0.write_en = 1'd1;
+      let0[done] = __i0.done;
+    }
+    group let1<"static"=1> {
+      __x_0.in = fp_const0.out;
+      __x_0.write_en = 1'd1;
+      let1[done] = __x_0.done;
+    }
+    group let2<"static"=1> {
+      __j0.in = const2.out;
+      __j0.write_en = 1'd1;
+      let2[done] = __j0.done;
+    }
+    group let3<"static"=2> {
+      red_read00.in = x20_0.out;
+      red_read00.write_en = x20_0.read_done;
+      let3[done] = red_read00.done;
+      x20_0.addr1 = __j0.out;
+      x20_0.addr0 = __i0.out;
+      x20_0.read_en = 1'd1;
+    }
+    group upd0<"static"=1> {
+      x20_0.addr1 = __j0.out;
+      x20_0.addr0 = __i0.out;
+      x20_0.write_en = 1'd1;
+      add0.left = red_read00.out;
+      add0.right = __x_0.out;
+      x20_0.in = add0.out;
+      upd0[done] = x20_0.write_done;
+    }
+    group upd1<"static"=1> {
+      __j0.write_en = 1'd1;
+      add1.left = __j0.out;
+      add1.right = const4.out;
+      __j0.in = add1.out;
+      upd1[done] = __j0.done;
+    }
+    group upd2<"static"=1> {
+      __i0.write_en = 1'd1;
+      add2.left = __i0.out;
+      add2.right = const5.out;
+      __i0.in = add2.out;
+      upd2[done] = __i0.done;
+    }
+  }
+  control {
+    seq {
+      @pos(0) let0;
+      @bound(1) while le0.out with cond0 {
+        seq {
+          @pos(1) let1;
+          @pos(2) let2;
+          @bound(2) while le1.out with cond1 {
+            seq {
+              let3;
+              upd0;
+              @pos(2) upd1;
+            }
+          }
+          @pos(0) upd2;
+        }
+      }
+    }
+  }
+}
+component main() -> () {
+  cells {
+    @external(1) A0_0 = seq_mem_d2(32,1,2,1,2);
+    use_plus_equals0 = use_plus_equals();
+  }
+  wires {
+  }
+  control {
+    seq {
+      invoke use_plus_equals0[x20_0=A0_0]()();
+    }
+  }
+}
+metadata #{
+  0:   for (let __i: ubit<1> = 0..1) {
+  1:     let __x: fix<32,16> = (2.0 as fix<32,16>);
+  2:     for (let __j: ubit<2> = 0..2) {
+}#

--- a/file-tests/should-futil/use-plus-equals.fuse
+++ b/file-tests/should-futil/use-plus-equals.fuse
@@ -1,0 +1,11 @@
+def use_plus_equals(x2: fix<32, 16>[1][2]) = {
+  for (let __i: ubit<1> = 0..1) {
+    let __x: fix<32,16> = (2.0 as fix<32,16>);
+    for (let __j: ubit<2> = 0..2) {
+      x2[__i][__j] += __x;
+    } 
+  }
+}
+
+decl A: fix<32,16>[1][2];
+use_plus_equals(A);


### PR DESCRIPTION
We need to pass mutli-cycle info for the `EArrAccess` case for `EmitExpr()` in the Calyx backend. Before we weren't and that was creating incorrect Calyx code for LeNet. 

I also added a test case that would have caught the error I was running into in LeNet (basically for when Dahlia has something like`A[i] += value`.  When translated into Calyx we have a register to store the variable value, but that register's `write_en` signal needs to be `A.read_done`. Before it was just `1'd1`.) 