### PR TITLE
Calyx Backend uses static groups instead of attribute

### DIFF
--- a/file-tests/should-futil/fixed-point-constant.expect
+++ b/file-tests/should-futil/fixed-point-constant.expect
@@ -13,25 +13,21 @@ component main() -> () {
     fp_const3 = std_const(15,19968);
   }
   wires {
-    group let0<"static"=1> {
+    static group <1> let0 {
       a_0.in = fp_const0.out;
       a_0.write_en = 1'd1;
-      let0[done] = a_0.done;
     }
-    group let1<"static"=1> {
+    static group <1> let1 {
       b_0.in = fp_const1.out;
       b_0.write_en = 1'd1;
-      let1[done] = b_0.done;
     }
-    group let2<"static"=1> {
+    static group <1> let2 {
       c_0.in = fp_const2.out;
       c_0.write_en = 1'd1;
-      let2[done] = c_0.done;
     }
-    group let3<"static"=1> {
+    static group <1> let3 {
       d_0.in = fp_const3.out;
       d_0.write_en = 1'd1;
-      let3[done] = d_0.done;
     }
   }
   control {

--- a/file-tests/should-futil/fixed-point-constant.expect
+++ b/file-tests/should-futil/fixed-point-constant.expect
@@ -13,19 +13,19 @@ component main() -> () {
     fp_const3 = std_const(15,19968);
   }
   wires {
-    static group <1> let0 {
+    static<1> group let0 {
       a_0.in = fp_const0.out;
       a_0.write_en = 1'd1;
     }
-    static group <1> let1 {
+    static<1> group let1 {
       b_0.in = fp_const1.out;
       b_0.write_en = 1'd1;
     }
-    static group <1> let2 {
+    static<1> group let2 {
       c_0.in = fp_const2.out;
       c_0.write_en = 1'd1;
     }
-    static group <1> let3 {
+    static<1> group let3 {
       d_0.in = fp_const3.out;
       d_0.write_en = 1'd1;
     }

--- a/file-tests/should-futil/fixed-point-multi-cycle.expect
+++ b/file-tests/should-futil/fixed-point-multi-cycle.expect
@@ -16,32 +16,28 @@ component main() -> () {
     mult_pipe1 = std_fp_mult_pipe(2,1,1);
   }
   wires {
-    group let0<"static"=4> {
+    static group <4> let0 {
       bin_read0_0.in = mult_pipe0.out;
       bin_read0_0.write_en = mult_pipe0.done;
-      let0[done] = bin_read0_0.done;
       mult_pipe0.left = fp_const0.out;
       mult_pipe0.right = fp_const1.out;
       mult_pipe0.go = !mult_pipe0.done ? 1'd1;
     }
-    group let1<"static"=1> {
+    static group <1> let1 {
       b_0.in = bin_read0_0.out;
       b_0.write_en = 1'd1;
-      let1[done] = b_0.done;
     }
-    group let2<"static"=4> {
+    static group <4> let2 {
       bin_read1_0.in = mult_pipe1.out;
       bin_read1_0.write_en = mult_pipe1.done;
-      let2[done] = bin_read1_0.done;
       mult_pipe1.left = fp_const2.out;
       mult_pipe1.right = fp_const3.out;
       mult_pipe1.go = !mult_pipe1.done ? 1'd1;
     }
-    group upd0<"static"=1> {
+    static group <1> upd0 {
       d0.addr0 = const0.out;
       d0.write_en = 1'd1;
       d0.write_data = bin_read1_0.out;
-      upd0[done] = d0.write_done;
     }
   }
   control {

--- a/file-tests/should-futil/fixed-point-multi-cycle.expect
+++ b/file-tests/should-futil/fixed-point-multi-cycle.expect
@@ -16,25 +16,25 @@ component main() -> () {
     mult_pipe1 = std_fp_mult_pipe(2,1,1);
   }
   wires {
-    static group <4> let0 {
+    static<4> group let0 {
       bin_read0_0.in = mult_pipe0.out;
       bin_read0_0.write_en = mult_pipe0.done;
       mult_pipe0.left = fp_const0.out;
       mult_pipe0.right = fp_const1.out;
       mult_pipe0.go = !mult_pipe0.done ? 1'd1;
     }
-    static group <1> let1 {
+    static<1> group let1 {
       b_0.in = bin_read0_0.out;
       b_0.write_en = 1'd1;
     }
-    static group <4> let2 {
+    static<4> group let2 {
       bin_read1_0.in = mult_pipe1.out;
       bin_read1_0.write_en = mult_pipe1.done;
       mult_pipe1.left = fp_const2.out;
       mult_pipe1.right = fp_const3.out;
       mult_pipe1.go = !mult_pipe1.done ? 1'd1;
     }
-    static group <1> upd0 {
+    static<1> group upd0 {
       d0.addr0 = const0.out;
       d0.write_en = 1'd1;
       d0.write_data = bin_read1_0.out;

--- a/file-tests/should-futil/for-multi-dim.expect
+++ b/file-tests/should-futil/for-multi-dim.expect
@@ -30,46 +30,40 @@ component main() -> () {
       le1.left = j0.out;
       le1.right = const3.out;
     }
-    group let0<"static"=1> {
+    static group <1> let0 {
       i0.in = const0.out;
       i0.write_en = 1'd1;
-      let0[done] = i0.done;
     }
-    group let1<"static"=1> {
+    static group <1> let1 {
       j0.in = const2.out;
       j0.write_en = 1'd1;
-      let1[done] = j0.done;
     }
-    group let2<"static"=2> {
+    static group <2> let2 {
       A_read0_0.in = A.read_data;
       A_read0_0.write_en = A.read_done;
-      let2[done] = A_read0_0.done;
       A.addr1 = j0.out;
       A.addr0 = i0.out;
       A.read_en = 1'd1;
     }
-    group upd0<"static"=1> {
+    static group <1> upd0 {
       B.addr1 = j0.out;
       B.addr0 = i0.out;
       B.write_en = 1'd1;
       add0.left = A_read0_0.out;
       add0.right = const4.out;
       B.write_data = add0.out;
-      upd0[done] = B.write_done;
     }
-    group upd1<"static"=1> {
+    static group <1> upd1 {
       j0.write_en = 1'd1;
       add1.left = j0.out;
       add1.right = const5.out;
       j0.in = add1.out;
-      upd1[done] = j0.done;
     }
-    group upd2<"static"=1> {
+    static group <1> upd2 {
       i0.write_en = 1'd1;
       add2.left = i0.out;
       add2.right = const6.out;
       i0.in = add2.out;
-      upd2[done] = i0.done;
     }
   }
   control {

--- a/file-tests/should-futil/for-multi-dim.expect
+++ b/file-tests/should-futil/for-multi-dim.expect
@@ -30,22 +30,22 @@ component main() -> () {
       le1.left = j0.out;
       le1.right = const3.out;
     }
-    static group <1> let0 {
+    static<1> group let0 {
       i0.in = const0.out;
       i0.write_en = 1'd1;
     }
-    static group <1> let1 {
+    static<1> group let1 {
       j0.in = const2.out;
       j0.write_en = 1'd1;
     }
-    static group <2> let2 {
+    static<2> group let2 {
       A_read0_0.in = A.read_data;
       A_read0_0.write_en = A.read_done;
       A.addr1 = j0.out;
       A.addr0 = i0.out;
       A.read_en = 1'd1;
     }
-    static group <1> upd0 {
+    static<1> group upd0 {
       B.addr1 = j0.out;
       B.addr0 = i0.out;
       B.write_en = 1'd1;
@@ -53,13 +53,13 @@ component main() -> () {
       add0.right = const4.out;
       B.write_data = add0.out;
     }
-    static group <1> upd1 {
+    static<1> group upd1 {
       j0.write_en = 1'd1;
       add1.left = j0.out;
       add1.right = const5.out;
       j0.in = add1.out;
     }
-    static group <1> upd2 {
+    static<1> group upd2 {
       i0.write_en = 1'd1;
       add2.left = i0.out;
       add2.right = const6.out;

--- a/file-tests/should-futil/for.expect
+++ b/file-tests/should-futil/for.expect
@@ -20,24 +20,24 @@ component main() -> () {
       le0.left = i0.out;
       le0.right = const1.out;
     }
-    static group <1> let0 {
+    static<1> group let0 {
       i0.in = const0.out;
       i0.write_en = 1'd1;
     }
-    static group <2> let1 {
+    static<2> group let1 {
       A_read0_0.in = A.read_data;
       A_read0_0.write_en = A.read_done;
       A.addr0 = i0.out;
       A.read_en = 1'd1;
     }
-    static group <1> upd0 {
+    static<1> group upd0 {
       B.addr0 = i0.out;
       B.write_en = 1'd1;
       add0.left = A_read0_0.out;
       add0.right = const2.out;
       B.write_data = add0.out;
     }
-    static group <1> upd1 {
+    static<1> group upd1 {
       i0.write_en = 1'd1;
       add1.left = i0.out;
       add1.right = const3.out;

--- a/file-tests/should-futil/for.expect
+++ b/file-tests/should-futil/for.expect
@@ -20,32 +20,28 @@ component main() -> () {
       le0.left = i0.out;
       le0.right = const1.out;
     }
-    group let0<"static"=1> {
+    static group <1> let0 {
       i0.in = const0.out;
       i0.write_en = 1'd1;
-      let0[done] = i0.done;
     }
-    group let1<"static"=2> {
+    static group <2> let1 {
       A_read0_0.in = A.read_data;
       A_read0_0.write_en = A.read_done;
-      let1[done] = A_read0_0.done;
       A.addr0 = i0.out;
       A.read_en = 1'd1;
     }
-    group upd0<"static"=1> {
+    static group <1> upd0 {
       B.addr0 = i0.out;
       B.write_en = 1'd1;
       add0.left = A_read0_0.out;
       add0.right = const2.out;
       B.write_data = add0.out;
-      upd0[done] = B.write_done;
     }
-    group upd1<"static"=1> {
+    static group <1> upd1 {
       i0.write_en = 1'd1;
       add1.left = i0.out;
       add1.right = const3.out;
       i0.in = add1.out;
-      upd1[done] = i0.done;
     }
   }
   control {

--- a/file-tests/should-futil/invoke-with-fixed-point.expect
+++ b/file-tests/should-futil/invoke-with-fixed-point.expect
@@ -6,7 +6,7 @@ component foo(x: 8) -> (@stable(1) out: 8) {
     y_0 = std_reg(8);
   }
   wires {
-    static group <1> let0 {
+    static<1> group let0 {
       y_0.in = x;
       y_0.write_en = 1'd1;
     }
@@ -24,7 +24,7 @@ component main() -> () {
     x_0 = std_reg(8);
   }
   wires {
-    static group <1> let1 {
+    static<1> group let1 {
       x_0.in = fp_const0.out;
       x_0.write_en = 1'd1;
     }

--- a/file-tests/should-futil/invoke-with-fixed-point.expect
+++ b/file-tests/should-futil/invoke-with-fixed-point.expect
@@ -6,10 +6,9 @@ component foo(x: 8) -> (@stable(1) out: 8) {
     y_0 = std_reg(8);
   }
   wires {
-    group let0<"static"=1> {
+    static group <1> let0 {
       y_0.in = x;
       y_0.write_en = 1'd1;
-      let0[done] = y_0.done;
     }
     out = y_0.out;
   }
@@ -25,10 +24,9 @@ component main() -> () {
     x_0 = std_reg(8);
   }
   wires {
-    group let1<"static"=1> {
+    static group <1> let1 {
       x_0.in = fp_const0.out;
       x_0.write_en = 1'd1;
-      let1[done] = x_0.done;
     }
     group let2 {
       tmp_0.in = foo0.out;

--- a/file-tests/should-futil/invoke-with-memories.expect
+++ b/file-tests/should-futil/invoke-with-memories.expect
@@ -10,23 +10,20 @@ component mem_copy() -> () {
     zero_0 = std_reg(1);
   }
   wires {
-    group let0<"static"=1> {
+    static group <1> let0 {
       zero_0.in = const0.out;
       zero_0.write_en = 1'd1;
-      let0[done] = zero_0.done;
     }
-    group let1<"static"=2> {
+    static group <2> let1 {
       src_read0_0.in = src.read_data;
       src_read0_0.write_en = src.read_done;
-      let1[done] = src_read0_0.done;
       src.addr0 = zero_0.out;
       src.read_en = 1'd1;
     }
-    group upd0<"static"=1> {
+    static group <1> upd0 {
       dest.addr0 = zero_0.out;
       dest.write_en = 1'd1;
       dest.write_data = src_read0_0.out;
-      upd0[done] = dest.write_done;
     }
   }
   control {

--- a/file-tests/should-futil/invoke-with-memories.expect
+++ b/file-tests/should-futil/invoke-with-memories.expect
@@ -10,17 +10,17 @@ component mem_copy() -> () {
     zero_0 = std_reg(1);
   }
   wires {
-    static group <1> let0 {
+    static<1> group let0 {
       zero_0.in = const0.out;
       zero_0.write_en = 1'd1;
     }
-    static group <2> let1 {
+    static<2> group let1 {
       src_read0_0.in = src.read_data;
       src_read0_0.write_en = src.read_done;
       src.addr0 = zero_0.out;
       src.read_en = 1'd1;
     }
-    static group <1> upd0 {
+    static<1> group upd0 {
       dest.addr0 = zero_0.out;
       dest.write_en = 1'd1;
       dest.write_data = src_read0_0.out;

--- a/file-tests/should-futil/invoke.expect
+++ b/file-tests/should-futil/invoke.expect
@@ -7,10 +7,9 @@ component foo(a: 32) -> (@stable(1) out: 32) {
     temp_0 = std_reg(32);
   }
   wires {
-    group let0<"static"=1> {
+    static group <1> let0 {
       temp_0.in = a;
       temp_0.write_en = 1'd1;
-      let0[done] = temp_0.done;
     }
     out = temp_0.out;
   }
@@ -28,10 +27,9 @@ component main() -> () {
     sqrt0 = sqrt(32);
   }
   wires {
-    group let1<"static"=1> {
+    static group <1> let1 {
       b_0.in = const0.out;
       b_0.write_en = 1'd1;
-      let1[done] = b_0.done;
     }
     group let2 {
       c_0.in = foo0.out;

--- a/file-tests/should-futil/invoke.expect
+++ b/file-tests/should-futil/invoke.expect
@@ -7,7 +7,7 @@ component foo(a: 32) -> (@stable(1) out: 32) {
     temp_0 = std_reg(32);
   }
   wires {
-    static group <1> let0 {
+    static<1> group let0 {
       temp_0.in = a;
       temp_0.write_en = 1'd1;
     }
@@ -27,7 +27,7 @@ component main() -> () {
     sqrt0 = sqrt(32);
   }
   wires {
-    static group <1> let1 {
+    static<1> group let1 {
       b_0.in = const0.out;
       b_0.write_en = 1'd1;
     }

--- a/file-tests/should-futil/sequentialize-reduce.expect
+++ b/file-tests/should-futil/sequentialize-reduce.expect
@@ -28,31 +28,31 @@ component main() -> () {
       le1.left = j0.out;
       le1.right = const4.out;
     }
-    static group <1> let0 {
+    static<1> group let0 {
       i0.in = const0.out;
       i0.write_en = 1'd1;
     }
-    static group <1> let1 {
+    static<1> group let1 {
       x_0.in = const2.out;
       x_0.write_en = 1'd1;
     }
-    static group <1> let2 {
+    static<1> group let2 {
       j0.in = const3.out;
       j0.write_en = 1'd1;
     }
-    static group <1> upd0 {
+    static<1> group upd0 {
       x_0.write_en = 1'd1;
       add0.left = x_0.out;
       add0.right = j0.out;
       x_0.in = add0.out;
     }
-    static group <1> upd1 {
+    static<1> group upd1 {
       j0.write_en = 1'd1;
       add1.left = j0.out;
       add1.right = const5.out;
       j0.in = add1.out;
     }
-    static group <1> upd2 {
+    static<1> group upd2 {
       i0.write_en = 1'd1;
       add2.left = i0.out;
       add2.right = const6.out;

--- a/file-tests/should-futil/sequentialize-reduce.expect
+++ b/file-tests/should-futil/sequentialize-reduce.expect
@@ -28,41 +28,35 @@ component main() -> () {
       le1.left = j0.out;
       le1.right = const4.out;
     }
-    group let0<"static"=1> {
+    static group <1> let0 {
       i0.in = const0.out;
       i0.write_en = 1'd1;
-      let0[done] = i0.done;
     }
-    group let1<"static"=1> {
+    static group <1> let1 {
       x_0.in = const2.out;
       x_0.write_en = 1'd1;
-      let1[done] = x_0.done;
     }
-    group let2<"static"=1> {
+    static group <1> let2 {
       j0.in = const3.out;
       j0.write_en = 1'd1;
-      let2[done] = j0.done;
     }
-    group upd0<"static"=1> {
+    static group <1> upd0 {
       x_0.write_en = 1'd1;
       add0.left = x_0.out;
       add0.right = j0.out;
       x_0.in = add0.out;
-      upd0[done] = x_0.done;
     }
-    group upd1<"static"=1> {
+    static group <1> upd1 {
       j0.write_en = 1'd1;
       add1.left = j0.out;
       add1.right = const5.out;
       j0.in = add1.out;
-      upd1[done] = j0.done;
     }
-    group upd2<"static"=1> {
+    static group <1> upd2 {
       i0.write_en = 1'd1;
       add2.left = i0.out;
       add2.right = const6.out;
       i0.in = add2.out;
-      upd2[done] = i0.done;
     }
   }
   control {

--- a/file-tests/should-futil/use-plus-equals.expect
+++ b/file-tests/should-futil/use-plus-equals.expect
@@ -30,51 +30,44 @@ component use_plus_equals() -> () {
       le1.left = __j0.out;
       le1.right = const3.out;
     }
-    group let0<"static"=1> {
+    static group <1> let0 {
       __i0.in = const0.out;
       __i0.write_en = 1'd1;
-      let0[done] = __i0.done;
     }
-    group let1<"static"=1> {
+    static group <1> let1 {
       __x_0.in = fp_const0.out;
       __x_0.write_en = 1'd1;
-      let1[done] = __x_0.done;
     }
-    group let2<"static"=1> {
+    static group <1> let2 {
       __j0.in = const2.out;
       __j0.write_en = 1'd1;
-      let2[done] = __j0.done;
     }
-    group let3<"static"=2> {
+    static group <2> let3 {
       red_read00.in = x2.read_data;
       red_read00.write_en = x2.read_done;
-      let3[done] = red_read00.done;
       x2.addr1 = __j0.out;
       x2.addr0 = __i0.out;
       x2.read_en = 1'd1;
     }
-    group upd0<"static"=1> {
+    static group <1> upd0 {
       x2.addr1 = __j0.out;
       x2.addr0 = __i0.out;
       x2.write_en = 1'd1;
       add0.left = red_read00.out;
       add0.right = __x_0.out;
       x2.write_data = add0.out;
-      upd0[done] = x2.write_done;
     }
-    group upd1<"static"=1> {
+    static group <1> upd1 {
       __j0.write_en = 1'd1;
       add1.left = __j0.out;
       add1.right = const4.out;
       __j0.in = add1.out;
-      upd1[done] = __j0.done;
     }
-    group upd2<"static"=1> {
+    static group <1> upd2 {
       __i0.write_en = 1'd1;
       add2.left = __i0.out;
       add2.right = const5.out;
       __i0.in = add2.out;
-      upd2[done] = __i0.done;
     }
   }
   control {

--- a/file-tests/should-futil/use-plus-equals.expect
+++ b/file-tests/should-futil/use-plus-equals.expect
@@ -30,26 +30,26 @@ component use_plus_equals() -> () {
       le1.left = __j0.out;
       le1.right = const3.out;
     }
-    static group <1> let0 {
+    static<1> group let0 {
       __i0.in = const0.out;
       __i0.write_en = 1'd1;
     }
-    static group <1> let1 {
+    static<1> group let1 {
       __x_0.in = fp_const0.out;
       __x_0.write_en = 1'd1;
     }
-    static group <1> let2 {
+    static<1> group let2 {
       __j0.in = const2.out;
       __j0.write_en = 1'd1;
     }
-    static group <2> let3 {
+    static<2> group let3 {
       red_read00.in = x2.read_data;
       red_read00.write_en = x2.read_done;
       x2.addr1 = __j0.out;
       x2.addr0 = __i0.out;
       x2.read_en = 1'd1;
     }
-    static group <1> upd0 {
+    static<1> group upd0 {
       x2.addr1 = __j0.out;
       x2.addr0 = __i0.out;
       x2.write_en = 1'd1;
@@ -57,13 +57,13 @@ component use_plus_equals() -> () {
       add0.right = __x_0.out;
       x2.write_data = add0.out;
     }
-    static group <1> upd1 {
+    static<1> group upd1 {
       __j0.write_en = 1'd1;
       add1.left = __j0.out;
       add1.right = const4.out;
       __j0.in = add1.out;
     }
-    static group <1> upd2 {
+    static<1> group upd2 {
       __i0.write_en = 1'd1;
       add2.left = __i0.out;
       add2.right = const5.out;

--- a/src/main/scala/backends/calyx/Ast.scala
+++ b/src/main/scala/backends/calyx/Ast.scala
@@ -201,10 +201,10 @@ object Calyx {
         dest.doc() <+> equal <+> guard.doc() <+> text("?") <+> src.doc() <> semi
       case Group(id, conns, delay, comb) =>
         (if (comb) text("comb ") else emptyDoc) <>
-          text("group") <+> id.doc() <>
-          (if (delay.isDefined)
-             angles(text("\"static\"") <> equal <> text(delay.get.toString()))
-           else emptyDoc) <+>
+          (if (delay.isDefined) text("static ") else emptyDoc) <>
+          text("group") <+> 
+          (if (delay.isDefined) angles(text(delay.get.toString())) <> text(" ") else emptyDoc) <>
+          id.doc() <+>
           scope(vsep(conns.map(_.doc())))
     }
 

--- a/src/main/scala/backends/calyx/Ast.scala
+++ b/src/main/scala/backends/calyx/Ast.scala
@@ -201,9 +201,8 @@ object Calyx {
         dest.doc() <+> equal <+> guard.doc() <+> text("?") <+> src.doc() <> semi
       case Group(id, conns, delay, comb) =>
         (if (comb) text("comb ") else emptyDoc) <>
-          (if (delay.isDefined) text("static ") else emptyDoc) <>
+          (if (delay.isDefined) text("static") <> angles(text(delay.get.toString())) <> text(" ") else emptyDoc) <>
           text("group") <+> 
-          (if (delay.isDefined) angles(text(delay.get.toString())) <> text(" ") else emptyDoc) <>
           id.doc() <+>
           scope(vsep(conns.map(_.doc())))
     }


### PR DESCRIPTION
Simple change to use `static group <lateny>` instead of `<"static"=latency>` for the Calyx backend. 