### PR TITLE
Fix parsing issue of hex numbers in cast expr

### DIFF
--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -102,7 +102,7 @@ case class Parser(input: String) {
     )
   def hex[K: P]: P[Expr] =
     positioned(
-      P("0x" ~/ CharIn("0-9a-fA-F").rep(1)).!.map((n: String) =>
+      P("0x" ~/ CharsWhileIn("0-9a-fA-F")).!.map((n: String) =>
         EInt(BigInt(n.substring(2), 16), 16)
       ).opaque("hexademical")
     )

--- a/src/test/scala/ParsingPositive.scala
+++ b/src/test/scala/ParsingPositive.scala
@@ -240,5 +240,9 @@ class ParsingTests extends org.scalatest.FunSuite {
     parseAst("""
       let x = (y as float);
       """)
+    parseAst("""
+      let x = (0x9e3779b9 as ubit<32>);
+      let y = (023615674671 as ubit<32>);
+      """)
   }
 }


### PR DESCRIPTION
## Summary

1. Make the parser use the same logic as Octal literals
2. Add tests for this scenario

Closes #411 