### PR TITLE
Support unrolling functions with scalar arguments inside unrolled loops

### DIFF
--- a/src/main/scala/common/Errors.scala
+++ b/src/main/scala/common/Errors.scala
@@ -88,7 +88,7 @@ object Errors {
       extends TypeError(s"$op cannot be inside an unrolled loop", pos)
 
   case class FuncInUnroll(pos: Position)
-      extends TypeError("Cannot call function inside unrolled loop.", pos)
+      extends TypeError("Cannot call function with non scalar arguments (like arrays) inside unrolled loop.", pos)
 
   // Unrolling and banking errors
   case class UnrollRangeError(pos: Position, rSize: Int, uFactor: Int)

--- a/src/test/scala/TypeCheckerSpec.scala
+++ b/src/test/scala/TypeCheckerSpec.scala
@@ -1009,15 +1009,26 @@ class TypeCheckerSpec extends FunSpec {
       }
     }
 
-    it("disallowed inside unrolled loops") {
+    it("should not allow functions with array arguments inside unrolled loops") {
       assertThrows[FuncInUnroll] {
         typeCheck("""
-          def bar(a: bool) = { }
+          def bar(a: bool[4]) = { }
           for (let i = 0..10) unroll 5 {
             bar(tre);
           }
           """)
       }
+    }
+
+    it("should allow functions with scalar args in unrolled loops") {
+      typeCheck(
+        """
+        def bar(a: bool) = { }
+        let tre: bool;
+        for (let i = 0..10) unroll 5 {
+          bar(tre);
+        }
+        """)
     }
 
     it("completely consume array parameters") {


### PR DESCRIPTION
Closes #418 

Summary:
1. Implement the trait `Tracker` in `WFEnv`, to track function definitions
    * I've kept the key as `Id -> FuncDef`. This could have been `Id -> Boolean`, but it seemed too specific to this scenario for the `WFEnv`
2. Add a `canHaveFunctionInUnroll` function which will check from the `env` if the function can be present inside a unrolled loop
3. Update existing test case (which had scalar arguments) and add a new test case (with an array in the argument)