### PR TITLE
[`@pos` metadata] Preserve position info for compiler-rewritten statements

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -14,6 +14,12 @@ jobs:
       with:
         java-version: 1.8
 
+    - name: Setup sbt launcher
+      uses: sbt/setup-sbt@v1
+
+    - name: Build and Test
+      run: sbt +test
+
     - name: Tool versions
       id: versions
       run: |

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -22,7 +22,7 @@ jobs:
     # Don't rebuild Dahlia if HEAD hash hasn't changed.
     - name: Cache Dahlia
       id: dahlia-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ./target
@@ -36,7 +36,7 @@ jobs:
 
     - name: Cache runt
       id: runt-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cargo/bin/runt
         key: runt-bin-${{ runner.os }}-${{ steps.versions.outputs.runt }}

--- a/file-tests/should-futil/fixed-point-multi-cycle.expect
+++ b/file-tests/should-futil/fixed-point-multi-cycle.expect
@@ -47,12 +47,14 @@ component main() -> () {
   }
   control {
     seq {
-      let0;
-      let1;
-      let2;
-      upd0;
+      @pos(0) let0;
+      @pos(0) let1;
+      @pos(1) let2;
+      @pos(1) upd0;
     }
   }
 }
 metadata #{
+  0: let b: ufix<2, 1> = (1.0 as ufix<2, 1>) * (1.0 as ufix<2, 1>);
+  1: d[0] := (1.0 as ufix<2, 1>) * (1.0 as ufix<2, 1>);
 }#

--- a/file-tests/should-futil/sequentialize-reduce.expect
+++ b/file-tests/should-futil/sequentialize-reduce.expect
@@ -62,7 +62,7 @@ component main() -> () {
           @pos(2) let2;
           repeat 10 {
             seq {
-              upd0;
+              @pos(3) upd0;
               @pos(2) upd1;
             }
           }
@@ -76,4 +76,5 @@ metadata #{
   0: for (let i: ubit<4> = 0..10) {
   1:   let x: ubit<4> = 0;
   2:   for (let j: ubit<4> = 0..10) {
+  3:     x += j;
 }#

--- a/file-tests/should-futil/use-plus-equals.expect
+++ b/file-tests/should-futil/use-plus-equals.expect
@@ -75,8 +75,8 @@ component use_plus_equals() -> () {
           @pos(2) let2;
           repeat 2 {
             seq {
-              let3;
-              upd0;
+              @pos(3) let3;
+              @pos(3) upd0;
               @pos(2) upd1;
             }
           }
@@ -103,4 +103,5 @@ metadata #{
   0:   for (let __i: ubit<1> = 0..1) {
   1:     let __x: fix<32,16> = (2.0 as fix<32,16>);
   2:     for (let __j: ubit<2> = 0..2) {
+  3:       x2[__i][__j] += __x;
 }#

--- a/runt.toml
+++ b/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 
 [[tests]]
 name = "compile vivado"

--- a/src/main/scala/backends/calyx/Backend.scala
+++ b/src/main/scala/backends/calyx/Backend.scala
@@ -1140,7 +1140,6 @@ private class CalyxBackendHelper {
 
 case object CalyxBackend extends fuselang.backend.Backend {
   def emitProg(p: Prog, c: Config) = {
-    println("CALYX!!! " + p)
     (new CalyxBackendHelper()).emitProg(p, c)
   }
   val canGenerateHeader = false

--- a/src/main/scala/backends/calyx/Backend.scala
+++ b/src/main/scala/backends/calyx/Backend.scala
@@ -987,14 +987,18 @@ private class CalyxBackendHelper {
 
         e1 match {
           case _: EVar =>
-            emitCmd(CUpdate(e1, EBinop(NumOp(op, numOp), e1, e2)))
+            val varCmd: Command = CUpdate(e1, EBinop(NumOp(op, numOp), e1, e2))
+            varCmd.withPos(c)
+            emitCmd(varCmd)
           case ea: EArrAccess => {
             // Create a binding for the memory read.
             val name = Id(genName("red_read").name)
             val bind = CLet(name, ea.typ, Some(ea))
+            bind.withPos(c)
             val nLhs = EVar(name)
             nLhs.typ = ea.typ;
             val upd = CUpdate(e1, EBinop(NumOp(op, numOp), nLhs, e2))
+            upd.withPos(c)
             emitCmd(CSeq.smart(Seq(bind, upd)))
           }
           case e =>
@@ -1136,6 +1140,7 @@ private class CalyxBackendHelper {
 
 case object CalyxBackend extends fuselang.backend.Backend {
   def emitProg(p: Prog, c: Config) = {
+    println("CALYX!!! " + p)
     (new CalyxBackendHelper()).emitProg(p, c)
   }
   val canGenerateHeader = false

--- a/src/main/scala/common/Transformer.scala
+++ b/src/main/scala/common/Transformer.scala
@@ -14,32 +14,51 @@ object Transformer:
     val emptyEnv: Env
 
     /**
+     * Helper function that copies the position of oldCmd to newCmd if
+     * newCmd does not have a non-zero position.
+     */
+    def updatePosIfEmpty(oldCmd: Command, newCmd: Command) = {
+      // If the position for the command is undefined, add the previous position
+      if newCmd.pos.line == 0 && newCmd.pos.column == 0 then
+        newCmd.withPos(oldCmd)
+    }
+
+    /**
+     * Recursive helper function to transfer positions onto commands and
+     * their child commands when commands are nested.
+     */
+    def transferPosHelper(oldCmd: Command, newCmd: Command): Unit = {
+      updatePosIfEmpty(oldCmd, newCmd)
+      // recurse on our new command if we need to.
+      newCmd match {
+        case CBlock(cmd) => transferPosHelper(oldCmd, cmd)
+        case CPar(cmds) => cmds.foreach(cmd => transferPosHelper(oldCmd, cmd))
+        case CSeq(cmds) => cmds.foreach(cmd => transferPosHelper(oldCmd, cmd))
+        case CFor(_, _, par: Command, combine: Command) => {
+          transferPosHelper(oldCmd, par)
+          transferPosHelper(oldCmd, combine)
+        }
+        case CIf(_, cons: Command, alt: Command) => {
+          transferPosHelper(oldCmd, cons)
+          transferPosHelper(oldCmd, alt)
+        }
+        case CWhile(_, _, body: Command) => {
+          transferPosHelper(oldCmd, body)
+        }
+        case _ => ()
+      }
+
+    }
+
+    /**
      * Transfer comments from one command to another.
      */
     def transferPos(cmd: Command, f: PF[(Command, Env), (Command, Env)])(
         implicit env: Env
     ): (Command, Env) =
       val (c1, env1) = f(cmd, env)
-
-      def updatePosIfEmpty(c: Command) = {
-        // If the position for the command is undefined, add the previous position
-        if c.pos.line == 0 && c.pos.column == 0 then
-          c.withPos(cmd)
-      }
-
-      // if inner commands (inside a seq/par/block) are "empty", update positions
-      c1 match
-        case p: CPar  => {
-          p.cmds.foreach(c => updatePosIfEmpty(c))
-        }
-        case s: CSeq => {
-          s.cmds.foreach(c => updatePosIfEmpty(c))
-        }
-        case b: CBlock => {
-          updatePosIfEmpty(b.cmd)
-        }
-        case _ => ()
-      updatePosIfEmpty(c1) // update the outermost command.
+      // recursive helper function to transfer positions over if empty
+      transferPosHelper(cmd, c1)
       (c1, env1)
 
     /**


### PR DESCRIPTION
Previously, there were certain Calyx control statements/blocks that didn't have a `@pos` metadata attached to them. We found that this was because positions of statements within a `seq` were not preserved under optimizing transformations. (More details in Calyx Zulip: [#development > &#96;@pos&#96; from Dahlia's Calyx backend @ 💬](https://calyx.zulipchat.com/#narrow/channel/423600-development/topic/.60.40pos.60.20from.20Dahlia's.20Calyx.20backend/near/527963555))

This PR also updates the Runt version to `0.4.1`!