### PR TITLE
[Calyx backend] Modify `@pos` to use new Calyx sourceinfo format

### DIFF
--- a/file-tests/should-futil/emit-signed-op.expect
+++ b/file-tests/should-futil/emit-signed-op.expect
@@ -99,15 +99,6 @@ component main() -> () {
     }
   }
 }
-metadata #{
-  0: decl a: bit<10>[128];
-  1:   c[i] := a[i] & b[i]; // This should not be emit signed Calyx primitive
-  2:   d[i] := a[i] + b[i]; // This should emit a signed Calyx primitive
-  3: decl b: bit<10>[128];
-  4: decl c: bit<10>[128];
-  5: decl d: bit<10>[128];
-  6: for (let i:bit<8>=0..128) {
-}#
 sourceinfo #{
   FILES
   0: file-tests/should-futil/emit-signed-op.fuse

--- a/file-tests/should-futil/emit-signed-op.expect
+++ b/file-tests/should-futil/emit-signed-op.expect
@@ -3,56 +3,56 @@ import "primitives/memories/seq.futil";
 import "primitives/binary_operators.futil";
 component main() -> () {
   cells {
-    @external(1) a = seq_mem_d1(10,128,8);
-    a_read0_0 = std_reg(10);
-    a_read1_0 = std_reg(10);
+    @pos{0} @external(1) a = seq_mem_d1(10,128,8);
+    @pos{1} a_read0_0 = std_reg(10);
+    @pos{2} a_read1_0 = std_reg(10);
     add0 = std_sadd(10);
     add1 = std_sadd(8);
     and0 = std_and(10);
-    @external(1) b = seq_mem_d1(10,128,8);
-    b_read0_0 = std_reg(10);
-    b_read1_0 = std_reg(10);
-    @external(1) c = seq_mem_d1(10,128,8);
+    @pos{3} @external(1) b = seq_mem_d1(10,128,8);
+    @pos{1} b_read0_0 = std_reg(10);
+    @pos{2} b_read1_0 = std_reg(10);
+    @pos{4} @external(1) c = seq_mem_d1(10,128,8);
     const0 = std_const(8,0);
     const1 = std_const(8,1);
-    @external(1) d = seq_mem_d1(10,128,8);
-    i0 = std_reg(8);
+    @pos{5} @external(1) d = seq_mem_d1(10,128,8);
+    @pos{6} i0 = std_reg(8);
   }
   wires {
-    group let0<"promotable"=1> {
+    group let0<"promotable"=1, "pos"={6}> {
       i0.in = const0.out;
       i0.write_en = 1'd1;
       let0[done] = i0.done;
     }
-    group let1<"promotable"=2> {
+    group let1<"promotable"=2, "pos"={1}> {
       a_read0_0.in = a.read_data;
       a_read0_0.write_en = a.done;
       let1[done] = a_read0_0.done;
       a.content_en = 1'd1;
       a.addr0 = i0.out;
     }
-    group let2<"promotable"=2> {
+    group let2<"promotable"=2, "pos"={1}> {
       b_read0_0.in = b.read_data;
       b_read0_0.write_en = b.done;
       let2[done] = b_read0_0.done;
       b.content_en = 1'd1;
       b.addr0 = i0.out;
     }
-    group let3<"promotable"=2> {
+    group let3<"promotable"=2, "pos"={2}> {
       a_read1_0.in = a.read_data;
       a_read1_0.write_en = a.done;
       let3[done] = a_read1_0.done;
       a.content_en = 1'd1;
       a.addr0 = i0.out;
     }
-    group let4<"promotable"=2> {
+    group let4<"promotable"=2, "pos"={2}> {
       b_read1_0.in = b.read_data;
       b_read1_0.write_en = b.done;
       let4[done] = b_read1_0.done;
       b.content_en = 1'd1;
       b.addr0 = i0.out;
     }
-    group upd0<"promotable"=1> {
+    group upd0<"promotable"=1, "pos"={1}> {
       c.content_en = 1'd1;
       c.addr0 = i0.out;
       c.write_en = 1'd1;
@@ -61,7 +61,7 @@ component main() -> () {
       c.write_data = and0.out;
       upd0[done] = c.done;
     }
-    group upd1<"promotable"=1> {
+    group upd1<"promotable"=1, "pos"={2}> {
       d.content_en = 1'd1;
       d.addr0 = i0.out;
       d.write_en = 1'd1;
@@ -70,7 +70,7 @@ component main() -> () {
       d.write_data = add0.out;
       upd1[done] = d.done;
     }
-    group upd2<"promotable"=1> {
+    group upd2<"promotable"=1, "pos"={6}> {
       i0.write_en = 1'd1;
       add1.left = i0.out;
       add1.right = const1.out;
@@ -80,31 +80,43 @@ component main() -> () {
   }
   control {
     seq {
-      @pos(0) let0;
+      @pos{6} let0;
       repeat 128 {
         seq {
           par {
-            @pos(1) let1;
-            @pos(2) let2;
+            @pos{1} let1;
+            @pos{1} let2;
           }
           par {
-            @pos(3) upd0;
-            @pos(4) let3;
-            @pos(5) let4;
+            @pos{1} upd0;
+            @pos{2} let3;
+            @pos{2} let4;
           }
-          @pos(6) upd1;
-          @pos(0) upd2;
+          @pos{2} upd1;
+          @pos{6} upd2;
         }
       }
     }
   }
 }
 metadata #{
-  0: for (let i:bit<8>=0..128) {
+  0: decl a: bit<10>[128];
   1:   c[i] := a[i] & b[i]; // This should not be emit signed Calyx primitive
-  2:   c[i] := a[i] & b[i]; // This should not be emit signed Calyx primitive
-  3:   c[i] := a[i] & b[i]; // This should not be emit signed Calyx primitive
-  4:   d[i] := a[i] + b[i]; // This should emit a signed Calyx primitive
-  5:   d[i] := a[i] + b[i]; // This should emit a signed Calyx primitive
-  6:   d[i] := a[i] + b[i]; // This should emit a signed Calyx primitive
+  2:   d[i] := a[i] + b[i]; // This should emit a signed Calyx primitive
+  3: decl b: bit<10>[128];
+  4: decl c: bit<10>[128];
+  5: decl d: bit<10>[128];
+  6: for (let i:bit<8>=0..128) {
+}#
+sourceinfo #{
+  FILES
+  0: file-tests/should-futil/emit-signed-op.fuse
+  POSITIONS
+  0: 0 1
+  1: 0 7
+  2: 0 8
+  3: 0 2
+  4: 0 3
+  5: 0 4
+  6: 0 6
 }#

--- a/file-tests/should-futil/fixed-point-constant.expect
+++ b/file-tests/should-futil/fixed-point-constant.expect
@@ -13,22 +13,22 @@ component main() -> () {
     fp_const3 = std_const(15,19968);
   }
   wires {
-    group let0<"promotable"=1> {
+    group let0<"promotable"=1, "pos"={0}> {
       a_0.in = fp_const0.out;
       a_0.write_en = 1'd1;
       let0[done] = a_0.done;
     }
-    group let1<"promotable"=1> {
+    group let1<"promotable"=1, "pos"={1}> {
       b_0.in = fp_const1.out;
       b_0.write_en = 1'd1;
       let1[done] = b_0.done;
     }
-    group let2<"promotable"=1> {
+    group let2<"promotable"=1, "pos"={2}> {
       c_0.in = fp_const2.out;
       c_0.write_en = 1'd1;
       let2[done] = c_0.done;
     }
-    group let3<"promotable"=1> {
+    group let3<"promotable"=1, "pos"={3}> {
       d_0.in = fp_const3.out;
       d_0.write_en = 1'd1;
       let3[done] = d_0.done;
@@ -36,10 +36,10 @@ component main() -> () {
   }
   control {
     par {
-      @pos(0) let0;
-      @pos(1) let1;
-      @pos(2) let2;
-      @pos(3) let3;
+      @pos{0} let0;
+      @pos{1} let1;
+      @pos{2} let2;
+      @pos{3} let3;
     }
   }
 }
@@ -48,4 +48,13 @@ metadata #{
   1: let b: fix<4, 2> = (-2.25 as fix<4, 2>); // 7
   2: let c: ufix<15, 3> = (3.125 as ufix<15, 3>); // 12800
   3: let d: fix<15, 3> = (-3.125 as fix<15, 3>); // 19668
+}#
+sourceinfo #{
+  FILES
+  0: file-tests/should-futil/fixed-point-constant.fuse
+  POSITIONS
+  0: 0 7
+  1: 0 8
+  2: 0 10
+  3: 0 11
 }#

--- a/file-tests/should-futil/fixed-point-constant.expect
+++ b/file-tests/should-futil/fixed-point-constant.expect
@@ -43,12 +43,6 @@ component main() -> () {
     }
   }
 }
-metadata #{
-  0: let a: ufix<4, 2> = (2.25 as ufix<4, 2>); // 9
-  1: let b: fix<4, 2> = (-2.25 as fix<4, 2>); // 7
-  2: let c: ufix<15, 3> = (3.125 as ufix<15, 3>); // 12800
-  3: let d: fix<15, 3> = (-3.125 as fix<15, 3>); // 19668
-}#
 sourceinfo #{
   FILES
   0: file-tests/should-futil/fixed-point-constant.fuse

--- a/file-tests/should-futil/fixed-point-multi-cycle.expect
+++ b/file-tests/should-futil/fixed-point-multi-cycle.expect
@@ -54,11 +54,6 @@ component main() -> () {
     }
   }
 }
-metadata #{
-  0: let d: ufix<2, 1>[1];
-  1: let b: ufix<2, 1> = (1.0 as ufix<2, 1>) * (1.0 as ufix<2, 1>);
-  2: d[0] := (1.0 as ufix<2, 1>) * (1.0 as ufix<2, 1>);
-}#
 sourceinfo #{
   FILES
   0: file-tests/should-futil/fixed-point-multi-cycle.fuse

--- a/file-tests/should-futil/fixed-point-multi-cycle.expect
+++ b/file-tests/should-futil/fixed-point-multi-cycle.expect
@@ -7,7 +7,7 @@ component main() -> () {
     bin_read0_0 = std_reg(2);
     bin_read1_0 = std_reg(2);
     const0 = std_const(1,0);
-    d0 = seq_mem_d1(2,1,1);
+    @pos{0} d0 = seq_mem_d1(2,1,1);
     fp_const0 = std_const(2,2);
     fp_const1 = std_const(2,2);
     fp_const2 = std_const(2,2);
@@ -16,7 +16,7 @@ component main() -> () {
     mult_pipe1 = std_fp_mult_pipe(2,1,1);
   }
   wires {
-    group let0<"promotable"=4> {
+    group let0<"promotable"=4, "pos"={1}> {
       bin_read0_0.in = mult_pipe0.out;
       bin_read0_0.write_en = mult_pipe0.done;
       let0[done] = bin_read0_0.done;
@@ -24,12 +24,12 @@ component main() -> () {
       mult_pipe0.right = fp_const1.out;
       mult_pipe0.go = !mult_pipe0.done ? 1'd1;
     }
-    group let1<"promotable"=1> {
+    group let1<"promotable"=1, "pos"={1}> {
       b_0.in = bin_read0_0.out;
       b_0.write_en = 1'd1;
       let1[done] = b_0.done;
     }
-    group let2<"promotable"=4> {
+    group let2<"promotable"=4, "pos"={2}> {
       bin_read1_0.in = mult_pipe1.out;
       bin_read1_0.write_en = mult_pipe1.done;
       let2[done] = bin_read1_0.done;
@@ -37,7 +37,7 @@ component main() -> () {
       mult_pipe1.right = fp_const3.out;
       mult_pipe1.go = !mult_pipe1.done ? 1'd1;
     }
-    group upd0<"promotable"=1> {
+    group upd0<"promotable"=1, "pos"={2}> {
       d0.content_en = 1'd1;
       d0.addr0 = const0.out;
       d0.write_en = 1'd1;
@@ -47,14 +47,23 @@ component main() -> () {
   }
   control {
     seq {
-      @pos(0) let0;
-      @pos(0) let1;
-      @pos(1) let2;
-      @pos(1) upd0;
+      @pos{1} let0;
+      @pos{1} let1;
+      @pos{2} let2;
+      @pos{2} upd0;
     }
   }
 }
 metadata #{
-  0: let b: ufix<2, 1> = (1.0 as ufix<2, 1>) * (1.0 as ufix<2, 1>);
-  1: d[0] := (1.0 as ufix<2, 1>) * (1.0 as ufix<2, 1>);
+  0: let d: ufix<2, 1>[1];
+  1: let b: ufix<2, 1> = (1.0 as ufix<2, 1>) * (1.0 as ufix<2, 1>);
+  2: d[0] := (1.0 as ufix<2, 1>) * (1.0 as ufix<2, 1>);
+}#
+sourceinfo #{
+  FILES
+  0: file-tests/should-futil/fixed-point-multi-cycle.fuse
+  POSITIONS
+  0: 0 3
+  1: 0 1
+  2: 0 5
 }#

--- a/file-tests/should-futil/for-multi-dim.expect
+++ b/file-tests/should-futil/for-multi-dim.expect
@@ -80,13 +80,6 @@ component main() -> () {
     }
   }
 }
-metadata #{
-  0: decl A: bit<32>[10][2];
-  1:     B[i][j] := A[i][j] + 1;
-  2: decl B: bit<32>[10][2];
-  3: for (let i: ubit<4> = 0..10) {
-  4:   for (let j: ubit<2> = 0..2){
-}#
 sourceinfo #{
   FILES
   0: file-tests/should-futil/for-multi-dim.fuse

--- a/file-tests/should-futil/for-multi-dim.expect
+++ b/file-tests/should-futil/for-multi-dim.expect
@@ -3,9 +3,9 @@ import "primitives/memories/seq.futil";
 import "primitives/binary_operators.futil";
 component main() -> () {
   cells {
-    @external(1) A = seq_mem_d2(32,10,2,4,2);
-    A_read0_0 = std_reg(32);
-    @external(1) B = seq_mem_d2(32,10,2,4,2);
+    @pos{0} @external(1) A = seq_mem_d2(32,10,2,4,2);
+    @pos{1} A_read0_0 = std_reg(32);
+    @pos{2} @external(1) B = seq_mem_d2(32,10,2,4,2);
     add0 = std_sadd(32);
     add1 = std_add(2);
     add2 = std_add(4);
@@ -14,21 +14,21 @@ component main() -> () {
     const2 = std_const(32,1);
     const3 = std_const(2,1);
     const4 = std_const(4,1);
-    i0 = std_reg(4);
-    j0 = std_reg(2);
+    @pos{3} i0 = std_reg(4);
+    @pos{4} j0 = std_reg(2);
   }
   wires {
-    group let0<"promotable"=1> {
+    group let0<"promotable"=1, "pos"={3}> {
       i0.in = const0.out;
       i0.write_en = 1'd1;
       let0[done] = i0.done;
     }
-    group let1<"promotable"=1> {
+    group let1<"promotable"=1, "pos"={4}> {
       j0.in = const1.out;
       j0.write_en = 1'd1;
       let1[done] = j0.done;
     }
-    group let2<"promotable"=2> {
+    group let2<"promotable"=2, "pos"={1}> {
       A_read0_0.in = A.read_data;
       A_read0_0.write_en = A.done;
       let2[done] = A_read0_0.done;
@@ -36,7 +36,7 @@ component main() -> () {
       A.addr1 = j0.out;
       A.addr0 = i0.out;
     }
-    group upd0<"promotable"=1> {
+    group upd0<"promotable"=1, "pos"={1}> {
       B.content_en = 1'd1;
       B.addr1 = j0.out;
       B.addr0 = i0.out;
@@ -46,14 +46,14 @@ component main() -> () {
       B.write_data = add0.out;
       upd0[done] = B.done;
     }
-    group upd1<"promotable"=1> {
+    group upd1<"promotable"=1, "pos"={4}> {
       j0.write_en = 1'd1;
       add1.left = j0.out;
       add1.right = const3.out;
       j0.in = add1.out;
       upd1[done] = j0.done;
     }
-    group upd2<"promotable"=1> {
+    group upd2<"promotable"=1, "pos"={3}> {
       i0.write_en = 1'd1;
       add2.left = i0.out;
       add2.right = const4.out;
@@ -63,26 +63,37 @@ component main() -> () {
   }
   control {
     seq {
-      @pos(0) let0;
+      @pos{3} let0;
       repeat 10 {
         seq {
-          @pos(1) let1;
+          @pos{4} let1;
           repeat 2 {
             seq {
-              @pos(2) let2;
-              @pos(3) upd0;
-              @pos(1) upd1;
+              @pos{1} let2;
+              @pos{1} upd0;
+              @pos{4} upd1;
             }
           }
-          @pos(0) upd2;
+          @pos{3} upd2;
         }
       }
     }
   }
 }
 metadata #{
-  0: for (let i: ubit<4> = 0..10) {
-  1:   for (let j: ubit<2> = 0..2){
-  2:     B[i][j] := A[i][j] + 1;
-  3:     B[i][j] := A[i][j] + 1;
+  0: decl A: bit<32>[10][2];
+  1:     B[i][j] := A[i][j] + 1;
+  2: decl B: bit<32>[10][2];
+  3: for (let i: ubit<4> = 0..10) {
+  4:   for (let j: ubit<2> = 0..2){
+}#
+sourceinfo #{
+  FILES
+  0: file-tests/should-futil/for-multi-dim.fuse
+  POSITIONS
+  0: 0 1
+  1: 0 6
+  2: 0 2
+  3: 0 4
+  4: 0 5
 }#

--- a/file-tests/should-futil/for.expect
+++ b/file-tests/should-futil/for.expect
@@ -56,12 +56,6 @@ component main() -> () {
     }
   }
 }
-metadata #{
-  0: decl A: bit<32>[10];
-  1:   B[i] := A[i] + 1;
-  2: decl B: bit<32>[10];
-  3: for (let i: ubit<4> = 0..10) {
-}#
 sourceinfo #{
   FILES
   0: file-tests/should-futil/for.fuse

--- a/file-tests/should-futil/for.expect
+++ b/file-tests/should-futil/for.expect
@@ -3,30 +3,30 @@ import "primitives/memories/seq.futil";
 import "primitives/binary_operators.futil";
 component main() -> () {
   cells {
-    @external(1) A = seq_mem_d1(32,10,4);
-    A_read0_0 = std_reg(32);
-    @external(1) B = seq_mem_d1(32,10,4);
+    @pos{0} @external(1) A = seq_mem_d1(32,10,4);
+    @pos{1} A_read0_0 = std_reg(32);
+    @pos{2} @external(1) B = seq_mem_d1(32,10,4);
     add0 = std_sadd(32);
     add1 = std_add(4);
     const0 = std_const(4,0);
     const1 = std_const(32,1);
     const2 = std_const(4,1);
-    i0 = std_reg(4);
+    @pos{3} i0 = std_reg(4);
   }
   wires {
-    group let0<"promotable"=1> {
+    group let0<"promotable"=1, "pos"={3}> {
       i0.in = const0.out;
       i0.write_en = 1'd1;
       let0[done] = i0.done;
     }
-    group let1<"promotable"=2> {
+    group let1<"promotable"=2, "pos"={1}> {
       A_read0_0.in = A.read_data;
       A_read0_0.write_en = A.done;
       let1[done] = A_read0_0.done;
       A.content_en = 1'd1;
       A.addr0 = i0.out;
     }
-    group upd0<"promotable"=1> {
+    group upd0<"promotable"=1, "pos"={1}> {
       B.content_en = 1'd1;
       B.addr0 = i0.out;
       B.write_en = 1'd1;
@@ -35,7 +35,7 @@ component main() -> () {
       B.write_data = add0.out;
       upd0[done] = B.done;
     }
-    group upd1<"promotable"=1> {
+    group upd1<"promotable"=1, "pos"={3}> {
       i0.write_en = 1'd1;
       add1.left = i0.out;
       add1.right = const2.out;
@@ -45,19 +45,29 @@ component main() -> () {
   }
   control {
     seq {
-      @pos(0) let0;
+      @pos{3} let0;
       repeat 10 {
         seq {
-          @pos(1) let1;
-          @pos(2) upd0;
-          @pos(0) upd1;
+          @pos{1} let1;
+          @pos{1} upd0;
+          @pos{3} upd1;
         }
       }
     }
   }
 }
 metadata #{
-  0: for (let i: ubit<4> = 0..10) {
+  0: decl A: bit<32>[10];
   1:   B[i] := A[i] + 1;
-  2:   B[i] := A[i] + 1;
+  2: decl B: bit<32>[10];
+  3: for (let i: ubit<4> = 0..10) {
+}#
+sourceinfo #{
+  FILES
+  0: file-tests/should-futil/for.fuse
+  POSITIONS
+  0: 0 1
+  1: 0 5
+  2: 0 2
+  3: 0 4
 }#

--- a/file-tests/should-futil/invoke-with-fixed-point.expect
+++ b/file-tests/should-futil/invoke-with-fixed-point.expect
@@ -6,7 +6,7 @@ component foo(x: 8) -> (@stable(1) out: 8) {
     y_0 = std_reg(8);
   }
   wires {
-    group let0<"promotable"=1> {
+    group let0<"promotable"=1, "pos"={0}> {
       y_0.in = x;
       y_0.write_en = 1'd1;
       let0[done] = y_0.done;
@@ -14,7 +14,7 @@ component foo(x: 8) -> (@stable(1) out: 8) {
     out = y_0.out;
   }
   control {
-    @pos(0) let0;
+    @pos{0} let0;
   }
 }
 component main() -> () {
@@ -25,12 +25,12 @@ component main() -> () {
     x_0 = std_reg(8);
   }
   wires {
-    group let1<"promotable"=1> {
+    group let1<"promotable"=1, "pos"={1}> {
       x_0.in = fp_const0.out;
       x_0.write_en = 1'd1;
       let1[done] = x_0.done;
     }
-    group let2 {
+    group let2<"pos"={2}> {
       tmp_0.in = foo0.out;
       tmp_0.write_en = 1'd1;
       let2[done] = tmp_0.done;
@@ -38,9 +38,9 @@ component main() -> () {
   }
   control {
     seq {
-      @pos(1) let1;
+      @pos{1} let1;
       invoke foo0(x=x_0.out)();
-      @pos(2) let2;
+      @pos{2} let2;
     }
   }
 }
@@ -48,4 +48,12 @@ metadata #{
   0:   let y: ufix<8, 4> = x;
   1: let x: ufix<8, 4> = (1.0 as ufix<8, 4>);
   2: let tmp: ufix<8, 4> = foo(x);
+}#
+sourceinfo #{
+  FILES
+  0: file-tests/should-futil/invoke-with-fixed-point.fuse
+  POSITIONS
+  0: 0 2
+  1: 0 6
+  2: 0 7
 }#

--- a/file-tests/should-futil/invoke-with-fixed-point.expect
+++ b/file-tests/should-futil/invoke-with-fixed-point.expect
@@ -44,11 +44,6 @@ component main() -> () {
     }
   }
 }
-metadata #{
-  0:   let y: ufix<8, 4> = x;
-  1: let x: ufix<8, 4> = (1.0 as ufix<8, 4>);
-  2: let tmp: ufix<8, 4> = foo(x);
-}#
 sourceinfo #{
   FILES
   0: file-tests/should-futil/invoke-with-fixed-point.fuse

--- a/file-tests/should-futil/invoke-with-memories.expect
+++ b/file-tests/should-futil/invoke-with-memories.expect
@@ -6,23 +6,23 @@ component mem_copy() -> () {
     ref dest = seq_mem_d1(32,1,1);
     ref src = seq_mem_d1(32,1,1);
     const0 = std_const(1,0);
-    src_read0_0 = std_reg(32);
-    zero_0 = std_reg(1);
+    @pos{0} src_read0_0 = std_reg(32);
+    @pos{1} zero_0 = std_reg(1);
   }
   wires {
-    group let0<"promotable"=1> {
+    group let0<"promotable"=1, "pos"={1}> {
       zero_0.in = const0.out;
       zero_0.write_en = 1'd1;
       let0[done] = zero_0.done;
     }
-    group let1<"promotable"=2> {
+    group let1<"promotable"=2, "pos"={0}> {
       src_read0_0.in = src.read_data;
       src_read0_0.write_en = src.done;
       let1[done] = src_read0_0.done;
       src.content_en = 1'd1;
       src.addr0 = zero_0.out;
     }
-    group upd0<"promotable"=1> {
+    group upd0<"promotable"=1, "pos"={0}> {
       dest.content_en = 1'd1;
       dest.addr0 = zero_0.out;
       dest.write_en = 1'd1;
@@ -32,17 +32,17 @@ component mem_copy() -> () {
   }
   control {
     seq {
-      @pos(0) let0;
-      @pos(1) let1;
-      @pos(2) upd0;
+      @pos{1} let0;
+      @pos{0} let1;
+      @pos{0} upd0;
     }
   }
 }
 component main() -> () {
   cells {
-    @external(1) d = seq_mem_d1(32,1,1);
+    @pos{2} @external(1) d = seq_mem_d1(32,1,1);
     mem_copy0 = mem_copy();
-    @external(1) s = seq_mem_d1(32,1,1);
+    @pos{3} @external(1) s = seq_mem_d1(32,1,1);
   }
   wires {
   }
@@ -53,7 +53,17 @@ component main() -> () {
   }
 }
 metadata #{
-  0:   let zero = (0 as ubit<1>);
-  1:   dest[zero] := src[zero];
-  2:   dest[zero] := src[zero];
+  0:   dest[zero] := src[zero];
+  1:   let zero = (0 as ubit<1>);
+  2: decl d: ubit<32>[1];
+  3: decl s: ubit<32>[1];
+}#
+sourceinfo #{
+  FILES
+  0: file-tests/should-futil/invoke-with-memories.fuse
+  POSITIONS
+  0: 0 3
+  1: 0 2
+  2: 0 7
+  3: 0 6
 }#

--- a/file-tests/should-futil/invoke-with-memories.expect
+++ b/file-tests/should-futil/invoke-with-memories.expect
@@ -52,12 +52,6 @@ component main() -> () {
     }
   }
 }
-metadata #{
-  0:   dest[zero] := src[zero];
-  1:   let zero = (0 as ubit<1>);
-  2: decl d: ubit<32>[1];
-  3: decl s: ubit<32>[1];
-}#
 sourceinfo #{
   FILES
   0: file-tests/should-futil/invoke-with-memories.fuse

--- a/file-tests/should-futil/invoke.expect
+++ b/file-tests/should-futil/invoke.expect
@@ -54,12 +54,6 @@ component main() -> () {
     }
   }
 }
-metadata #{
-  0:   let temp: ubit<32> = a;
-  1: let b: ubit<32> = (1 as ubit<32>);
-  2: let c: ubit<32> = foo(b);
-  3: let d: ubit<32> = sqrt(c);
-}#
 sourceinfo #{
   FILES
   0: file-tests/should-futil/invoke.fuse

--- a/file-tests/should-futil/invoke.expect
+++ b/file-tests/should-futil/invoke.expect
@@ -4,10 +4,10 @@ import "primitives/binary_operators.futil";
 import "primitives/math.futil";
 component foo(a: 32) -> (@stable(1) out: 32) {
   cells {
-    temp_0 = std_reg(32);
+    @pos{0} temp_0 = std_reg(32);
   }
   wires {
-    group let0<"promotable"=1> {
+    group let0<"promotable"=1, "pos"={0}> {
       temp_0.in = a;
       temp_0.write_en = 1'd1;
       let0[done] = temp_0.done;
@@ -15,12 +15,12 @@ component foo(a: 32) -> (@stable(1) out: 32) {
     out = temp_0.out;
   }
   control {
-    @pos(0) let0;
+    @pos{0} let0;
   }
 }
 component main() -> () {
   cells {
-    b_0 = std_reg(32);
+    @pos{1} b_0 = std_reg(32);
     c_0 = std_reg(32);
     const0 = std_const(32,1);
     d_0 = std_reg(32);
@@ -28,17 +28,17 @@ component main() -> () {
     sqrt0 = sqrt(32);
   }
   wires {
-    group let1<"promotable"=1> {
+    group let1<"promotable"=1, "pos"={1}> {
       b_0.in = const0.out;
       b_0.write_en = 1'd1;
       let1[done] = b_0.done;
     }
-    group let2 {
+    group let2<"pos"={2}> {
       c_0.in = foo0.out;
       c_0.write_en = 1'd1;
       let2[done] = c_0.done;
     }
-    group let3 {
+    group let3<"pos"={3}> {
       d_0.in = sqrt0.out;
       d_0.write_en = 1'd1;
       let3[done] = d_0.done;
@@ -46,11 +46,11 @@ component main() -> () {
   }
   control {
     seq {
-      @pos(1) let1;
+      @pos{1} let1;
       invoke foo0(a=b_0.out)();
-      @pos(2) let2;
+      @pos{2} let2;
       invoke sqrt0(in=c_0.out)();
-      @pos(3) let3;
+      @pos{3} let3;
     }
   }
 }
@@ -59,4 +59,13 @@ metadata #{
   1: let b: ubit<32> = (1 as ubit<32>);
   2: let c: ubit<32> = foo(b);
   3: let d: ubit<32> = sqrt(c);
+}#
+sourceinfo #{
+  FILES
+  0: file-tests/should-futil/invoke.fuse
+  POSITIONS
+  0: 0 4
+  1: 0 8
+  2: 0 9
+  3: 0 10
 }#

--- a/file-tests/should-futil/sequentialize-reduce.expect
+++ b/file-tests/should-futil/sequentialize-reduce.expect
@@ -72,12 +72,6 @@ component main() -> () {
     }
   }
 }
-metadata #{
-  0: for (let i: ubit<4> = 0..10) {
-  1:   for (let j: ubit<4> = 0..10) {
-  2:   let x: ubit<4> = 0;
-  3:     x += j;
-}#
 sourceinfo #{
   FILES
   0: file-tests/should-futil/sequentialize-reduce.fuse

--- a/file-tests/should-futil/sequentialize-reduce.expect
+++ b/file-tests/should-futil/sequentialize-reduce.expect
@@ -11,41 +11,41 @@ component main() -> () {
     const2 = std_const(4,0);
     const3 = std_const(4,1);
     const4 = std_const(4,1);
-    i0 = std_reg(4);
-    j0 = std_reg(4);
-    x_0 = std_reg(4);
+    @pos{0} i0 = std_reg(4);
+    @pos{1} j0 = std_reg(4);
+    @pos{2} x_0 = std_reg(4);
   }
   wires {
-    group let0<"promotable"=1> {
+    group let0<"promotable"=1, "pos"={0}> {
       i0.in = const0.out;
       i0.write_en = 1'd1;
       let0[done] = i0.done;
     }
-    group let1<"promotable"=1> {
+    group let1<"promotable"=1, "pos"={2}> {
       x_0.in = const1.out;
       x_0.write_en = 1'd1;
       let1[done] = x_0.done;
     }
-    group let2<"promotable"=1> {
+    group let2<"promotable"=1, "pos"={1}> {
       j0.in = const2.out;
       j0.write_en = 1'd1;
       let2[done] = j0.done;
     }
-    group upd0<"promotable"=1> {
+    group upd0<"promotable"=1, "pos"={3}> {
       x_0.write_en = 1'd1;
       add0.left = x_0.out;
       add0.right = j0.out;
       x_0.in = add0.out;
       upd0[done] = x_0.done;
     }
-    group upd1<"promotable"=1> {
+    group upd1<"promotable"=1, "pos"={1}> {
       j0.write_en = 1'd1;
       add1.left = j0.out;
       add1.right = const3.out;
       j0.in = add1.out;
       upd1[done] = j0.done;
     }
-    group upd2<"promotable"=1> {
+    group upd2<"promotable"=1, "pos"={0}> {
       i0.write_en = 1'd1;
       add2.left = i0.out;
       add2.right = const4.out;
@@ -55,18 +55,18 @@ component main() -> () {
   }
   control {
     seq {
-      @pos(0) let0;
+      @pos{0} let0;
       repeat 10 {
         seq {
-          @pos(1) let1;
-          @pos(2) let2;
+          @pos{2} let1;
+          @pos{1} let2;
           repeat 10 {
             seq {
-              @pos(3) upd0;
-              @pos(2) upd1;
+              @pos{3} upd0;
+              @pos{1} upd1;
             }
           }
-          @pos(0) upd2;
+          @pos{0} upd2;
         }
       }
     }
@@ -74,7 +74,16 @@ component main() -> () {
 }
 metadata #{
   0: for (let i: ubit<4> = 0..10) {
-  1:   let x: ubit<4> = 0;
-  2:   for (let j: ubit<4> = 0..10) {
+  1:   for (let j: ubit<4> = 0..10) {
+  2:   let x: ubit<4> = 0;
   3:     x += j;
+}#
+sourceinfo #{
+  FILES
+  0: file-tests/should-futil/sequentialize-reduce.fuse
+  POSITIONS
+  0: 0 1
+  1: 0 3
+  2: 0 2
+  3: 0 4
 }#

--- a/file-tests/should-futil/use-plus-equals.expect
+++ b/file-tests/should-futil/use-plus-equals.expect
@@ -99,13 +99,6 @@ component main() -> () {
     }
   }
 }
-metadata #{
-  0:   for (let __i: ubit<1> = 0..1) {
-  1:     for (let __j: ubit<2> = 0..2) {
-  2:     let __x: fix<32,16> = (2.0 as fix<32,16>);
-  3:       x2[__i][__j] += __x;
-  4: decl A: fix<32,16>[1][2];
-}#
 sourceinfo #{
   FILES
   0: file-tests/should-futil/use-plus-equals.fuse

--- a/file-tests/should-futil/use-plus-equals.expect
+++ b/file-tests/should-futil/use-plus-equals.expect
@@ -4,8 +4,8 @@ import "primitives/binary_operators.futil";
 component use_plus_equals() -> () {
   cells {
     ref x2 = seq_mem_d2(32,1,2,1,2);
-    __i0 = std_reg(1);
-    __j0 = std_reg(2);
+    @pos{0} __i0 = std_reg(1);
+    @pos{1} __j0 = std_reg(2);
     __x_0 = std_reg(32);
     add0 = std_fp_sadd(32,16,16);
     add1 = std_add(2);
@@ -18,22 +18,22 @@ component use_plus_equals() -> () {
     red_read00 = std_reg(32);
   }
   wires {
-    group let0<"promotable"=1> {
+    group let0<"promotable"=1, "pos"={0}> {
       __i0.in = const0.out;
       __i0.write_en = 1'd1;
       let0[done] = __i0.done;
     }
-    group let1<"promotable"=1> {
+    group let1<"promotable"=1, "pos"={2}> {
       __x_0.in = fp_const0.out;
       __x_0.write_en = 1'd1;
       let1[done] = __x_0.done;
     }
-    group let2<"promotable"=1> {
+    group let2<"promotable"=1, "pos"={1}> {
       __j0.in = const1.out;
       __j0.write_en = 1'd1;
       let2[done] = __j0.done;
     }
-    group let3<"promotable"=2> {
+    group let3<"promotable"=2, "pos"={3}> {
       red_read00.in = x2.read_data;
       red_read00.write_en = x2.done;
       let3[done] = red_read00.done;
@@ -41,7 +41,7 @@ component use_plus_equals() -> () {
       x2.addr1 = __j0.out;
       x2.addr0 = __i0.out;
     }
-    group upd0<"promotable"=1> {
+    group upd0<"promotable"=1, "pos"={3}> {
       x2.content_en = 1'd1;
       x2.addr1 = __j0.out;
       x2.addr0 = __i0.out;
@@ -51,14 +51,14 @@ component use_plus_equals() -> () {
       x2.write_data = add0.out;
       upd0[done] = x2.done;
     }
-    group upd1<"promotable"=1> {
+    group upd1<"promotable"=1, "pos"={1}> {
       __j0.write_en = 1'd1;
       add1.left = __j0.out;
       add1.right = const2.out;
       __j0.in = add1.out;
       upd1[done] = __j0.done;
     }
-    group upd2<"promotable"=1> {
+    group upd2<"promotable"=1, "pos"={0}> {
       __i0.write_en = 1'd1;
       add2.left = __i0.out;
       add2.right = const3.out;
@@ -68,19 +68,19 @@ component use_plus_equals() -> () {
   }
   control {
     seq {
-      @pos(0) let0;
+      @pos{0} let0;
       repeat 1 {
         seq {
-          @pos(1) let1;
-          @pos(2) let2;
+          @pos{2} let1;
+          @pos{1} let2;
           repeat 2 {
             seq {
-              @pos(3) let3;
-              @pos(3) upd0;
-              @pos(2) upd1;
+              @pos{3} let3;
+              @pos{3} upd0;
+              @pos{1} upd1;
             }
           }
-          @pos(0) upd2;
+          @pos{0} upd2;
         }
       }
     }
@@ -88,7 +88,7 @@ component use_plus_equals() -> () {
 }
 component main() -> () {
   cells {
-    @external(1) A = seq_mem_d2(32,1,2,1,2);
+    @pos{4} @external(1) A = seq_mem_d2(32,1,2,1,2);
     use_plus_equals0 = use_plus_equals();
   }
   wires {
@@ -101,7 +101,18 @@ component main() -> () {
 }
 metadata #{
   0:   for (let __i: ubit<1> = 0..1) {
-  1:     let __x: fix<32,16> = (2.0 as fix<32,16>);
-  2:     for (let __j: ubit<2> = 0..2) {
+  1:     for (let __j: ubit<2> = 0..2) {
+  2:     let __x: fix<32,16> = (2.0 as fix<32,16>);
   3:       x2[__i][__j] += __x;
+  4: decl A: fix<32,16>[1][2];
+}#
+sourceinfo #{
+  FILES
+  0: file-tests/should-futil/use-plus-equals.fuse
+  POSITIONS
+  0: 0 2
+  1: 0 4
+  2: 0 3
+  3: 0 5
+  4: 0 10
 }#

--- a/src/main/scala/backends/calyx/Ast.scala
+++ b/src/main/scala/backends/calyx/Ast.scala
@@ -15,8 +15,6 @@ object Calyx:
   case class Metadata(
       // the name of the file
       filename: File,
-      // metadata: Mapping from longString to value of the counter
-      metadataMap: MutableMap[String, Int] = MutableMap(),
       // Mapping from line number to the value of the counter
       sourceLocMap: MutableMap[Int, Int] = MutableMap(),
       var counter: Int = 0,
@@ -25,27 +23,10 @@ object Calyx:
       val key = pos.line
       if !this.sourceLocMap.contains(key) then
         this.sourceLocMap.update(pos.line, this.counter)
-        this.metadataMap.update(pos.longString, this.counter)
         this.counter = this.counter + 1
       this.sourceLocMap(key)
 
     override def doc(): Doc =
-      text("metadata") <+> scope(
-        vsep(
-          this.metadataMap.toSeq
-            .sortBy(_._2)
-            .map({ case (longString, c) =>
-              text(c.toString()) <> text(":") <+> text(
-                longString.split("\n")(0)
-              )
-            })
-        ),
-        left = text("#") <> lbrace,
-        right = rbrace <> text("#")
-      )
-      <>
-      line
-      <>
       text("sourceinfo") <+> scope(
         text("FILES")
         <> line <>

--- a/src/main/scala/backends/calyx/Ast.scala
+++ b/src/main/scala/backends/calyx/Ast.scala
@@ -59,6 +59,7 @@ object Calyx:
               text(c.toString()) <> text(":") <+> text("0") <+> text(
                 pos.line.toString()
               )
+              <+> text(pos.column.toString())
             })
         ),
         left = text("#") <> lbrace,

--- a/src/main/scala/backends/calyx/Backend.scala
+++ b/src/main/scala/backends/calyx/Backend.scala
@@ -1034,7 +1034,7 @@ private class CalyxBackendHelper {
 
   def emitProg(p: Prog, c: Config): String = {
 
-    implicit val meta = Metadata()
+    implicit val meta = Metadata(c.srcFile)
 
     val importDefinitions = p.includes.flatMap(_.defs).toList
     val definitions =


### PR DESCRIPTION
This PR modifies the Calyx backend and the way it deals with `@pos` annotations.
First, instead of the old `metadata` block the Calyx backend produces the new `sourceinfo` block, which contains a `FILES` map and a `POSITIONS` map. Second, the Calyx backend adds `@pos` annotations to groups and cells wherever possible, while previously it only added `@pos` annotations to control nodes.

NOTE: This PR also made `@pos` ids ignore column numbers (so Calyx constructs that come from the same line of Dahlia code have the same `@pos` id). If we want to include column numbers in the future, we can change this!