### PR TITLE
[Calyx backend] Adding in `pos` attributes to control blocks

### DIFF
--- a/file-tests/should-futil/emit-signed-op.expect
+++ b/file-tests/should-futil/emit-signed-op.expect
@@ -79,15 +79,15 @@ component main() -> () {
     }
   }
   control {
-    seq {
+    @pos{6} seq {
       @pos{6} let0;
-      repeat 128 {
-        seq {
-          par {
+      @pos{6} repeat 128 {
+        @pos{6} seq {
+          @pos{1} par {
             @pos{1} let1;
             @pos{1} let2;
           }
-          par {
+          @pos{2} par {
             @pos{1} upd0;
             @pos{2} let3;
             @pos{2} let4;

--- a/file-tests/should-futil/fixed-point-constant.expect
+++ b/file-tests/should-futil/fixed-point-constant.expect
@@ -35,7 +35,7 @@ component main() -> () {
     }
   }
   control {
-    par {
+    @pos{3} par {
       @pos{0} let0;
       @pos{1} let1;
       @pos{2} let2;

--- a/file-tests/should-futil/fixed-point-multi-cycle.expect
+++ b/file-tests/should-futil/fixed-point-multi-cycle.expect
@@ -46,7 +46,7 @@ component main() -> () {
     }
   }
   control {
-    seq {
+    @pos{2} seq {
       @pos{1} let0;
       @pos{1} let1;
       @pos{2} let2;

--- a/file-tests/should-futil/for-multi-dim.expect
+++ b/file-tests/should-futil/for-multi-dim.expect
@@ -62,13 +62,13 @@ component main() -> () {
     }
   }
   control {
-    seq {
+    @pos{3} seq {
       @pos{3} let0;
-      repeat 10 {
-        seq {
+      @pos{3} repeat 10 {
+        @pos{3} seq {
           @pos{4} let1;
-          repeat 2 {
-            seq {
+          @pos{4} repeat 2 {
+            @pos{4} seq {
               @pos{1} let2;
               @pos{1} upd0;
               @pos{4} upd1;

--- a/file-tests/should-futil/for.expect
+++ b/file-tests/should-futil/for.expect
@@ -44,10 +44,10 @@ component main() -> () {
     }
   }
   control {
-    seq {
+    @pos{3} seq {
       @pos{3} let0;
-      repeat 10 {
-        seq {
+      @pos{3} repeat 10 {
+        @pos{3} seq {
           @pos{1} let1;
           @pos{1} upd0;
           @pos{3} upd1;

--- a/file-tests/should-futil/invoke-with-memories.expect
+++ b/file-tests/should-futil/invoke-with-memories.expect
@@ -31,7 +31,7 @@ component mem_copy() -> () {
     }
   }
   control {
-    seq {
+    @pos{0} seq {
       @pos{1} let0;
       @pos{0} let1;
       @pos{0} upd0;

--- a/file-tests/should-futil/sequentialize-reduce.expect
+++ b/file-tests/should-futil/sequentialize-reduce.expect
@@ -54,14 +54,14 @@ component main() -> () {
     }
   }
   control {
-    seq {
+    @pos{0} seq {
       @pos{0} let0;
-      repeat 10 {
-        seq {
+      @pos{0} repeat 10 {
+        @pos{0} seq {
           @pos{2} let1;
           @pos{1} let2;
-          repeat 10 {
-            seq {
+          @pos{1} repeat 10 {
+            @pos{1} seq {
               @pos{3} upd0;
               @pos{1} upd1;
             }

--- a/file-tests/should-futil/use-plus-equals.expect
+++ b/file-tests/should-futil/use-plus-equals.expect
@@ -67,14 +67,14 @@ component use_plus_equals() -> () {
     }
   }
   control {
-    seq {
+    @pos{0} seq {
       @pos{0} let0;
-      repeat 1 {
-        seq {
+      @pos{0} repeat 1 {
+        @pos{0} seq {
           @pos{2} let1;
           @pos{1} let2;
-          repeat 2 {
-            seq {
+          @pos{1} repeat 2 {
+            @pos{1} seq {
               @pos{3} let3;
               @pos{3} upd0;
               @pos{1} upd1;

--- a/src/main/scala/backends/calyx/Backend.scala
+++ b/src/main/scala/backends/calyx/Backend.scala
@@ -931,9 +931,12 @@ private class CalyxBackendHelper {
                 condOut.delay,
                 false
               )
+            val newIf = If(condOut.port, group.id, tCon, fCon)
+            newIf.withPos(c)
             val control = SeqComp(
-              List(Enable(group.id), If(condOut.port, group.id, tCon, fCon))
+              List(Enable(group.id), newIf)
             )
+            control.withPos(c)
             (group :: st ++ struct, control, store)
           }
           case None => {
@@ -944,7 +947,9 @@ private class CalyxBackendHelper {
                 condOut.delay,
                 true
               )
+            group.withPos(c)
             val control = If(condOut.port, group.id, tCon, fCon)
+            control.withPos(c)
             (group :: st ++ struct, control, store)
           }
         }
@@ -955,6 +960,7 @@ private class CalyxBackendHelper {
         wh.attributes.get("bound") match {
           case Some(count) => {
             val control = Repeat(count, bodyCon)
+            control.withPos(wh)
             (bodyStruct, control, st)
           }
           case None => {
@@ -973,6 +979,7 @@ private class CalyxBackendHelper {
               )
             condGroup.withPos(wh)
             val control = While(condOut.port, condGroup.id, bodyCon)
+            control.withPos(wh)
             control.attributes = wh.attributes
             (condGroup :: bodyStruct ++ condDefs, control, st)
           }


### PR DESCRIPTION
This PR adds `pos` attributes to Calyx-backend generated control blocks (`seq`, `par`, `if`, `while`, `repeat`)! This is so we can potentially map back from control blocks in Calyx to the specific line of Dahlia.